### PR TITLE
Add navmesh automation CI, scripts and docs

### DIFF
--- a/.github/workflows/navmesh-automation.yml
+++ b/.github/workflows/navmesh-automation.yml
@@ -1,0 +1,129 @@
+name: Navmesh Automation (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      executable_path:
+        description: "Path to dedicated executable on runner"
+        required: true
+        type: string
+      map_list_file:
+        description: "Map list file path on runner"
+        required: false
+        default: "scripts/nav_maps_example.txt"
+        type: string
+      query_pairs_file:
+        description: "Optional CSV query pairs file for deterministic path checks"
+        required: false
+        default: ""
+        type: string
+      expected_stats_file:
+        description: "Optional CSV expected world_tiles baseline"
+        required: false
+        default: ""
+        type: string
+      profile_budget_file:
+        description: "Optional CSV perf budget file for nav_profile_dashboard"
+        required: false
+        default: ""
+        type: string
+      require_query_pairs:
+        description: "Fail maps that have no query pairs when smoke is enabled"
+        required: false
+        default: false
+        type: boolean
+      run_bake:
+        description: "Run offline bake step"
+        required: false
+        default: true
+        type: boolean
+      run_smoke:
+        description: "Run smoke regression step"
+        required: false
+        default: true
+        type: boolean
+      run_profile_dashboard:
+        description: "Generate nav profile dashboard from smoke logs"
+        required: false
+        default: true
+        type: boolean
+      fail_on_profile_budget:
+        description: "Fail workflow when profile budget file is violated"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  navmesh-automation:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Validate script inputs
+        shell: powershell
+        run: |
+          if (-not (Test-Path -LiteralPath "${{ github.event.inputs.executable_path }}")) {
+            throw "Executable not found: ${{ github.event.inputs.executable_path }}"
+          }
+          if ("${{ github.event.inputs.map_list_file }}" -and -not (Test-Path -LiteralPath "${{ github.event.inputs.map_list_file }}")) {
+            throw "Map list file not found: ${{ github.event.inputs.map_list_file }}"
+          }
+          if ("${{ github.event.inputs.query_pairs_file }}" -and -not (Test-Path -LiteralPath "${{ github.event.inputs.query_pairs_file }}")) {
+            throw "Query pairs file not found: ${{ github.event.inputs.query_pairs_file }}"
+          }
+          if ("${{ github.event.inputs.expected_stats_file }}" -and -not (Test-Path -LiteralPath "${{ github.event.inputs.expected_stats_file }}")) {
+            throw "Expected stats file not found: ${{ github.event.inputs.expected_stats_file }}"
+          }
+          if ("${{ github.event.inputs.profile_budget_file }}" -and -not (Test-Path -LiteralPath "${{ github.event.inputs.profile_budget_file }}")) {
+            throw "Profile budget file not found: ${{ github.event.inputs.profile_budget_file }}"
+          }
+
+      - name: Run navmesh bake + smoke pipeline
+        shell: powershell
+        run: |
+          $args = @(
+            "-ExecutionPolicy", "Bypass",
+            "-File", "scripts/nav_pipeline.ps1",
+            "-Executable", "${{ github.event.inputs.executable_path }}",
+            "-MapListFile", "${{ github.event.inputs.map_list_file }}"
+          )
+
+          if ("${{ github.event.inputs.query_pairs_file }}") {
+            $args += @("-QueryPairsFile", "${{ github.event.inputs.query_pairs_file }}")
+          }
+          if ("${{ github.event.inputs.expected_stats_file }}") {
+            $args += @("-ExpectedStatsFile", "${{ github.event.inputs.expected_stats_file }}")
+          }
+          if ("${{ github.event.inputs.require_query_pairs }}" -eq "true") {
+            $args += "-RequireQueryPairs"
+          }
+          if ("${{ github.event.inputs.run_profile_dashboard }}" -eq "true") {
+            $args += "-RunProfileDashboard"
+          }
+          if ("${{ github.event.inputs.profile_budget_file }}") {
+            $args += @("-ProfileBudgetFile", "${{ github.event.inputs.profile_budget_file }}")
+          }
+          if ("${{ github.event.inputs.fail_on_profile_budget }}" -eq "true") {
+            $args += "-FailOnProfileBudget"
+          }
+
+          if ("${{ github.event.inputs.run_bake }}" -eq "false") {
+            $args += "-SkipBake"
+          }
+          if ("${{ github.event.inputs.run_smoke }}" -eq "false") {
+            $args += "-SkipSmoke"
+          }
+
+          & powershell @args
+
+      - name: Upload nav automation logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: navmesh-automation-logs
+          path: |
+            build-nav/nav-bake-logs/
+            build-nav/nav-regression-logs/

--- a/.github/workflows/navmesh-ci.yml
+++ b/.github/workflows/navmesh-ci.yml
@@ -1,0 +1,174 @@
+name: Navmesh CI
+
+on:
+  push:
+    branches: [ master, development ]
+    paths:
+      - ".github/workflows/navmesh-ci.yml"
+      - ".github/workflows/navmesh-automation.yml"
+      - "src/baseq2rtxp/svgame/nav/**"
+      - "src/baseq2rtxp/svgame/svg_commands_server.cpp"
+      - "scripts/nav_*.ps1"
+      - "scripts/nav_*.csv"
+      - "scripts/nav_*.txt"
+      - "docs/NAVMESH_*.md"
+  pull_request:
+    branches: [ master, development ]
+    paths:
+      - ".github/workflows/navmesh-ci.yml"
+      - ".github/workflows/navmesh-automation.yml"
+      - "src/baseq2rtxp/svgame/nav/**"
+      - "src/baseq2rtxp/svgame/svg_commands_server.cpp"
+      - "scripts/nav_*.ps1"
+      - "scripts/nav_*.csv"
+      - "scripts/nav_*.txt"
+      - "docs/NAVMESH_*.md"
+  workflow_dispatch:
+
+concurrency:
+  group: navmesh-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUILD_TYPE: RelWithDebInfo
+  NAV_CMAKE_FLAGS: >-
+    -DCONFIG_BUILD_CLIENT_TARGET=OFF
+    -DCONFIG_BUILD_SERVER_TARGET=OFF
+    -DCONFIG_BUILD_GAME_BASEQ2_TARGETS=OFF
+    -DCONFIG_BUILD_GAME_BASEQ2RTXP_TARGETS=ON
+    -DCONFIG_BUILD_FTEQW_IQM_TOOL=OFF
+    -DCONFIG_BUILD_DEV_MATHS_VERIFIER=OFF
+    -DCONFIG_VKPT_RENDERER=OFF
+    -DCONFIG_GL_RENDERER=OFF
+    -DCONFIG_USE_CURL=OFF
+    -DCONFIG_BUILD_GLSLANG=OFF
+
+jobs:
+  nav-build-matrix:
+    name: Nav Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: cmake -S . -B build-nav-ci -A x64 -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} ${{ env.NAV_CMAKE_FLAGS }}
+
+      - name: Configure (Linux)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: cmake -S . -B build-nav-ci -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${NAV_CMAKE_FLAGS}
+
+      - name: Build nav targets
+        run: cmake --build build-nav-ci --target baseq2rtxp_svgame --config ${{ env.BUILD_TYPE }} --parallel 2
+
+  nav-sanitizers:
+    name: Nav Sanitizers (Linux)
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+      CFLAGS: -O1 -g -fno-omit-frame-pointer -fsanitize=address,undefined
+      CXXFLAGS: -O1 -g -fno-omit-frame-pointer -fsanitize=address,undefined
+      LDFLAGS: -fsanitize=address,undefined
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install sanitizer toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld
+
+      - name: Configure
+        shell: bash
+        run: cmake -S . -B build-nav-sanitized -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${NAV_CMAKE_FLAGS}
+
+      - name: Build nav targets with ASan/UBSan
+        run: cmake --build build-nav-sanitized --target baseq2rtxp_svgame --config ${{ env.BUILD_TYPE }} --parallel 2
+
+  nav-static-analysis:
+    name: Nav Static Analysis (clang-tidy)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang clang-tidy
+
+      - name: Configure compile commands
+        shell: bash
+        run: cmake -S . -B build-nav-tidy -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${NAV_CMAKE_FLAGS}
+
+      - name: Run clang-tidy on nav sources
+        shell: bash
+        run: |
+          set -o pipefail
+          files=(
+            src/baseq2rtxp/svgame/nav/svg_nav.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_generate.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_request.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_traversal.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_traversal_async.cpp
+            src/baseq2rtxp/svgame/svg_commands_server.cpp
+          )
+          clang-tidy "${files[@]}" \
+            -p build-nav-tidy \
+            -checks='-*,clang-analyzer-core.*,clang-analyzer-cplusplus.*' \
+            2>&1 | tee build-nav-tidy/clang-tidy-nav.txt
+
+      - name: Upload clang-tidy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: navmesh-clang-tidy-report
+          path: build-nav-tidy/clang-tidy-nav.txt
+
+  nav-format-check:
+    name: Nav Formatting (clang-format)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Run clang-format dry-run
+        shell: bash
+        run: |
+          files=(
+            src/baseq2rtxp/svgame/nav/svg_nav.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_agent.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_generate.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_request.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_traversal.cpp
+            src/baseq2rtxp/svgame/nav/svg_nav_traversal_async.cpp
+            src/baseq2rtxp/svgame/entities/monster/svg_monster_testdummy_puppet.cpp
+            src/baseq2rtxp/svgame/svg_commands_server.cpp
+          )
+          clang-format --dry-run --Werror "${files[@]}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "C_Cpp.default.compileCommands": "e:\\Repositories\\Q2RTXPerimental\\extern\\sol2-develop-07-13-2024\\builddir/compile_commands.json",
+    "C_Cpp.default.configurationProvider": "mesonbuild.mesonbuild"
+}

--- a/CMakeSources.cmake
+++ b/CMakeSources.cmake
@@ -444,6 +444,7 @@ SET(SRC_BASEQ2RTXP_SVGAME
 	baseq2rtxp/svgame/weapons/svg_weapon_pistol.cpp
 	
     baseq2rtxp/svgame/nav/svg_nav.cpp
+    baseq2rtxp/svgame/nav/svg_nav_agent.cpp
     baseq2rtxp/svgame/nav/svg_nav_clusters.cpp
     baseq2rtxp/svgame/nav/svg_nav_debug.cpp
     baseq2rtxp/svgame/nav/svg_nav_generate.cpp
@@ -479,6 +480,7 @@ SET(HEADERS_BASEQ2RTXP_SVGAME
 	baseq2rtxp/svgame/svg_weapons.h
 
     baseq2rtxp/svgame/nav/svg_nav.H
+    baseq2rtxp/svgame/nav/svg_nav_agent.h
     baseq2rtxp/svgame/nav/svg_nav_clusters.h
     baseq2rtxp/svgame/nav/svg_nav_debug.h
     baseq2rtxp/svgame/nav/svg_nav_generate.h

--- a/docs/NAVMESH_AUTOMATION.md
+++ b/docs/NAVMESH_AUTOMATION.md
@@ -1,0 +1,161 @@
+# Navmesh Automation
+
+This document provides practical automation for two production tasks from the navmesh roadmap:
+
+- Offline nav-cache baking during content/asset builds.
+- Headless nav regression smoke tests.
+
+Coordinate-space invariants used by these tools are documented in:
+
+- `docs/NAVMESH_COORDINATE_SPACES.md`
+
+## Scripts
+
+- `scripts/nav_bake_maps.ps1`
+- `scripts/nav_regression_smoke.ps1`
+- `scripts/nav_profile_dashboard.ps1`
+- `scripts/nav_pipeline.ps1`
+- `scripts/nav_maps_example.txt`
+- `scripts/nav_query_pairs_example.csv`
+- `scripts/nav_expected_stats_example.csv`
+- `scripts/nav_profile_budget_example.csv`
+
+Both scripts run the dedicated server executable in headless mode and issue server commands via command-line `+` arguments.
+
+## Offline Bake
+
+Example:
+
+```powershell
+.\scripts\nav_bake_maps.ps1 `
+  -Executable .\build-nav\Bin\Q2RTXPerimental_ded.exe `
+  -Maps q2rtxp_dev_sigio_targetrange q2dm1
+```
+
+Map list file example (one map per line, `#` comments allowed):
+
+```text
+# maps for nav bake
+q2rtxp_dev_sigio_targetrange
+q2dm1
+```
+
+```powershell
+.\scripts\nav_bake_maps.ps1 `
+  -Executable .\build-nav\Bin\Q2RTXPerimental_ded.exe `
+  -MapListFile .\build-nav\nav_maps.txt
+```
+
+The script bakes `<map>.vans` files using `sv nav_bake` and validates that each cache was written to:
+
+- `baseq2rtxp/maps/nav/`
+
+Cache loads now enforce map/parameter hash matching by default (`nav_cache_require_hash_match 1`), so stale files cleanly miss and can be rebaked.
+
+## Regression Smoke Harness
+
+Example:
+
+```powershell
+.\scripts\nav_regression_smoke.ps1 `
+  -Executable .\build-nav\Bin\Q2RTXPerimental_ded.exe `
+  -Maps q2rtxp_dev_sigio_targetrange q2dm1
+```
+
+For each map, the harness runs:
+
+- `sv nav_gen_voxelmesh`
+- `sv nav_selftest 256`
+- `sv nav_query_path ...` (for each configured query pair)
+- `sv nav_profile_dump`
+
+And validates:
+
+- `nav_selftest` reports `result=PASS`
+- profile dump exists in log output
+- `mesh_loaded=1`
+- `world_tiles > 0`
+- optional exact `world_tiles` match from `-ExpectedStatsFile`
+- optional deterministic query outcomes from `-QueryPairsFile`
+
+`nav_profile_dump` includes generation timings (`world_ms`, `inline_ms`, `total_ms`), async queue metrics, and backend detour prototype metrics (`detour_*`) for dashboarding and budget checks.
+
+Logs are written under:
+
+- `build-nav/nav-regression-logs/`
+
+Query pairs CSV format:
+
+```text
+# map,id,start_x,start_y,start_z,goal_x,goal_y,goal_z,expect_found,expect_segments_ok
+q2dm1,q0,-128,64,24,512,256,24,1,1
+```
+
+Expected world-tile baseline CSV format:
+
+```text
+# map,world_tiles
+q2dm1,1234
+```
+
+Example with deterministic query/stat checks enabled:
+
+```powershell
+.\scripts\nav_regression_smoke.ps1 `
+  -Executable .\build-nav\Bin\Q2RTXPerimental_ded.exe `
+  -MapListFile .\scripts\nav_maps_example.txt `
+  -QueryPairsFile .\scripts\nav_query_pairs_example.csv `
+  -ExpectedStatsFile .\scripts\nav_expected_stats_example.csv `
+  -RequireQueryPairs
+```
+
+## Profiling Dashboard and Budgets
+
+Generate per-map dashboard outputs from smoke logs:
+
+```powershell
+.\scripts\nav_profile_dashboard.ps1
+```
+
+Outputs:
+
+- `build-nav/nav-regression-logs/nav_profile_dashboard.csv`
+- `build-nav/nav-regression-logs/nav_profile_dashboard.md`
+
+Optional budget validation:
+
+```powershell
+.\scripts\nav_profile_dashboard.ps1 `
+  -BudgetFile .\scripts\nav_profile_budget_example.csv `
+  -FailOnBudget
+```
+
+Budget CSVs can gate both queue/generation and backend detour behavior:
+
+- `max_world_gen_ms`, `max_inline_gen_ms`, `max_total_gen_ms`
+- `max_queue_frame_ms`, `max_queue_wait_avg_ms`, `max_over_budget_frames`
+- `max_detour_avg_ms`, `max_detour_points_after`
+- `min_world_tiles`
+
+## Combined Pipeline
+
+Run bake + smoke in one command:
+
+```powershell
+.\scripts\nav_pipeline.ps1 `
+  -Executable .\build-nav\Bin\Q2RTXPerimental_ded.exe `
+  -MapListFile .\scripts\nav_maps_example.txt `
+  -QueryPairsFile .\scripts\nav_query_pairs_example.csv `
+  -ExpectedStatsFile .\scripts\nav_expected_stats_example.csv `
+  -RunProfileDashboard `
+  -ProfileBudgetFile .\scripts\nav_profile_budget_example.csv
+```
+
+## CI/Pipeline Notes
+
+- Use `nav_bake_maps.ps1` in post-map-build steps to generate and ship cache assets.
+- Use `nav_regression_smoke.ps1` as a quick guardrail in CI for deterministic nav bootstrapping on curated maps.
+- Use `nav_profile_dashboard.ps1` to publish perf/capacity snapshots and enforce queue/generation budgets.
+- Use `.github/workflows/navmesh-ci.yml` for automatic nav-target validation on push/PR (Windows + Linux builds, Linux sanitizer build, Linux clang-tidy scan).
+- Keep map lists small and representative to avoid long CI times.
+- A manual GitHub Actions entry point is provided at `.github/workflows/navmesh-automation.yml` for runner setups that already have a dedicated executable and map assets available.

--- a/docs/NAVMESH_COORDINATE_SPACES.md
+++ b/docs/NAVMESH_COORDINATE_SPACES.md
@@ -1,0 +1,43 @@
+# Navmesh Coordinate Spaces
+
+This document defines the coordinate-space invariants used by the nav system.
+
+## Spaces
+
+- `feet-origin`:
+  - Caller-facing world-space origin where `z` is at agent feet.
+  - Used by gameplay/AI code and server command inputs.
+- `nav-center`:
+  - Internal world-space origin centered on the active agent hull.
+  - Used for node lookup, A*, and step/drop edge validation.
+- `model-local`:
+  - Inline-model local space used to store mover tile/cell/layer data.
+  - Converted to/from world via rigid transforms at generation/query/debug time.
+
+## Required Conversions
+
+- `feet-origin -> nav-center`:
+  - `SVG_Nav_ConvertFeetToCenter(...)`
+- `nav-center -> feet-origin`:
+  - `SVG_Nav_ConvertCenterToFeet(...)`
+- `model-local <-> world` (points):
+  - `SVG_Nav_WorldFromLocal(...)`
+  - `SVG_Nav_LocalFromWorld(...)`
+- `model-local <-> world` (directions):
+  - `SVG_Nav_WorldDirectionFromLocal(...)`
+  - `SVG_Nav_LocalDirectionFromWorld(...)`
+
+## Invariants
+
+- Public traversal APIs accept `feet-origin` coordinates.
+- A* and node resolution operate in `nav-center`.
+- Inline model sampling traces in world space, then stores layer hits in model-local.
+- Runtime inline-model queries/debug draw convert model-local samples back to world consistently via rigid transforms.
+
+## Validation
+
+- `sv nav_selftest [iterations]` checks:
+  - rigid transform point/direction round-trip errors
+  - feet-origin/nav-center inverse conversion
+  - tile/cell boundary conversion sanity
+- `scripts/nav_regression_smoke.ps1` runs `sv nav_selftest 256` per map and fails if result is not `PASS`.

--- a/docs/NAVMESH_TROUBLESHOOTING.md
+++ b/docs/NAVMESH_TROUBLESHOOTING.md
@@ -4,6 +4,17 @@
 
 This guide helps diagnose and fix pathfinding issues in the Q2RTXP navigation system.
 
+## Automation
+
+For headless bake/regression workflows used in productionization tasks, see:
+
+- `docs/NAVMESH_AUTOMATION.md`
+
+Quick deterministic diagnostics:
+
+- `sv nav_selftest 256`
+- `sv nav_query_path <start_x> <start_y> <start_z> <goal_x> <goal_y> <goal_z>`
+
 ## Common Issue: "No Path Found" with Large Z-Differences
 
 ### Symptoms

--- a/inc/common/common.h
+++ b/inc/common/common.h
@@ -141,9 +141,7 @@ QEXTERN_C_ENCLOSE( void        Com_AddConfigFile( const char *name, unsigned fla
 extern cvar_t   *z_perturb;
 #endif
 
-#if USE_DEBUG
 QEXTERN_C_ENCLOSE( extern cvar_t *developer; );
-#endif
 QEXTERN_C_ENCLOSE( extern cvar_t *dedicated; );
 #if USE_CLIENT
 extern cvar_t   *host_speeds;

--- a/scripts/nav_bake_maps.ps1
+++ b/scripts/nav_bake_maps.ps1
@@ -1,0 +1,126 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Executable,
+
+    [string[]]$Maps = @(),
+    [string]$MapListFile = "",
+
+    [string]$GameDirectory = "baseq2rtxp",
+    [string]$CacheExtension = "vans",
+    [int]$PerMapTimeoutSeconds = 120,
+
+    [switch]$RebuildExisting
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-MapList {
+    param(
+        [string[]]$InlineMaps,
+        [string]$MapFile
+    )
+
+    $result = New-Object System.Collections.Generic.List[string]
+
+    foreach ($map in $InlineMaps) {
+        $name = $map.Trim()
+        if ($name.Length -gt 0) {
+            $result.Add($name)
+        }
+    }
+
+    if ($MapFile -and (Test-Path -LiteralPath $MapFile)) {
+        foreach ($line in Get-Content -LiteralPath $MapFile) {
+            $trimmed = $line.Trim()
+            if ($trimmed.Length -eq 0) { continue }
+            if ($trimmed.StartsWith("#")) { continue }
+            $result.Add($trimmed)
+        }
+    }
+
+    return $result | Select-Object -Unique
+}
+
+if (-not (Test-Path -LiteralPath $Executable)) {
+    throw "Executable not found: $Executable"
+}
+
+$mapList = Get-MapList -InlineMaps $Maps -MapFile $MapListFile
+if ($mapList.Count -eq 0) {
+    throw "No maps provided. Use -Maps or -MapListFile."
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$cacheRoot = Join-Path $repoRoot "$GameDirectory/maps/nav"
+$logRoot = Join-Path $repoRoot "build-nav/nav-bake-logs"
+New-Item -ItemType Directory -Path $cacheRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $logRoot -Force | Out-Null
+
+$failures = New-Object System.Collections.Generic.List[string]
+
+foreach ($map in $mapList) {
+    $cacheFilename = "$map.$CacheExtension"
+    $cachePath = Join-Path $cacheRoot $cacheFilename
+    $logPath = Join-Path $logRoot ("bake_{0}_{1:yyyyMMdd_HHmmss}.log" -f $map, (Get-Date))
+
+    if ($RebuildExisting -and (Test-Path -LiteralPath $cachePath)) {
+        Remove-Item -LiteralPath $cachePath -Force
+    }
+
+    Write-Host ("[nav-bake] map={0} cache={1}" -f $map, $cacheFilename)
+
+    $args = @(
+        "+set", "dedicated", "1",
+        "+set", "developer", "1",
+        "+set", "cheats", "1",
+        "+set", "game", $GameDirectory,
+        "+set", "nav_cache_auto_load", "0",
+        "+set", "nav_cache_auto_bake_missing", "0",
+        "+set", "nav_cache_auto_save_after_bake", "0",
+        "+map", $map,
+        "+sv", "nav_bake", $cacheFilename,
+        "+quit"
+    )
+
+    $proc = Start-Process -FilePath $Executable `
+        -ArgumentList $args `
+        -WorkingDirectory $repoRoot `
+        -RedirectStandardOutput $logPath `
+        -RedirectStandardError $logPath `
+        -PassThru
+
+    if (-not $proc.WaitForExit($PerMapTimeoutSeconds * 1000)) {
+        try { $proc.Kill() } catch {}
+        $failures.Add("$map (timeout)")
+        Write-Host ("[nav-bake][FAIL] map={0} timed out ({1}s)" -f $map, $PerMapTimeoutSeconds)
+        continue
+    }
+
+    if ($proc.ExitCode -ne 0) {
+        $failures.Add("$map (exit $($proc.ExitCode))")
+        Write-Host ("[nav-bake][FAIL] map={0} exited with code {1}" -f $map, $proc.ExitCode)
+        continue
+    }
+
+    if (-not (Test-Path -LiteralPath $cachePath)) {
+        $failures.Add("$map (missing cache)")
+        Write-Host ("[nav-bake][FAIL] map={0} cache not found at {1}" -f $map, $cachePath)
+        continue
+    }
+
+    $sizeBytes = (Get-Item -LiteralPath $cachePath).Length
+    Write-Host ("[nav-bake][OK] map={0} wrote {1} ({2} bytes)" -f $map, $cacheFilename, $sizeBytes)
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host ""
+    Write-Host ("[nav-bake] FAILED: {0} map(s)" -f $failures.Count)
+    foreach ($f in $failures) {
+        Write-Host ("  - {0}" -f $f)
+    }
+    exit 1
+}
+
+Write-Host ""
+Write-Host ("[nav-bake] SUCCESS: baked {0} map(s)" -f $mapList.Count)
+exit 0

--- a/scripts/nav_expected_stats_example.csv
+++ b/scripts/nav_expected_stats_example.csv
@@ -1,0 +1,3 @@
+# map,world_tiles
+# Populate with your deterministic baseline values captured from nav_profile_dump.
+# q2dm1,1234

--- a/scripts/nav_maps_example.txt
+++ b/scripts/nav_maps_example.txt
@@ -1,0 +1,8 @@
+# Example map list for nav bake/smoke automation.
+# One map name per line.
+#
+# Update this file to match maps available in your local data setup.
+# These names are placeholders based on existing dev map naming.
+
+q2rtxp_dev_sigio_targetrange
+q2rtxp_dev_npc_puppet

--- a/scripts/nav_pipeline.ps1
+++ b/scripts/nav_pipeline.ps1
@@ -1,0 +1,134 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Executable,
+
+    [string[]]$Maps = @(),
+    [string]$MapListFile = "",
+    [string]$QueryPairsFile = "",
+    [string]$ExpectedStatsFile = "",
+    [switch]$RequireQueryPairs,
+    [switch]$RunProfileDashboard,
+    [string]$ProfileBudgetFile = "",
+    [switch]$FailOnProfileBudget,
+
+    [string]$GameDirectory = "baseq2rtxp",
+    [int]$PerMapTimeoutSeconds = 120,
+
+    [switch]$SkipBake,
+    [switch]$SkipSmoke,
+    [switch]$RebuildExisting
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$bakeScript = Join-Path $scriptRoot "nav_bake_maps.ps1"
+$smokeScript = Join-Path $scriptRoot "nav_regression_smoke.ps1"
+$profileScript = Join-Path $scriptRoot "nav_profile_dashboard.ps1"
+$profileRequested = $RunProfileDashboard -or $ProfileBudgetFile -or $FailOnProfileBudget
+$shouldRunProfileDashboard = $profileRequested -and (-not $SkipSmoke)
+
+if (-not (Test-Path -LiteralPath $bakeScript)) {
+    throw "Missing script: $bakeScript"
+}
+
+if (-not (Test-Path -LiteralPath $smokeScript)) {
+    throw "Missing script: $smokeScript"
+}
+
+if ($shouldRunProfileDashboard -and -not (Test-Path -LiteralPath $profileScript)) {
+    throw "Missing script: $profileScript"
+}
+
+if ($SkipBake -and $SkipSmoke) {
+    throw "Nothing to run: both -SkipBake and -SkipSmoke were specified."
+}
+
+if (-not (Test-Path -LiteralPath $Executable)) {
+    throw "Executable not found: $Executable"
+}
+
+if (-not $SkipBake) {
+    Write-Host "[nav-pipeline] STEP bake: caches"
+    $bakeArgs = @(
+        "-ExecutionPolicy", "Bypass",
+        "-File", $bakeScript,
+        "-Executable", $Executable,
+        "-GameDirectory", $GameDirectory,
+        "-PerMapTimeoutSeconds", $PerMapTimeoutSeconds
+    )
+
+    if ($Maps.Count -gt 0) {
+        $bakeArgs += @("-Maps") + $Maps
+    }
+    if ($MapListFile) {
+        $bakeArgs += @("-MapListFile", $MapListFile)
+    }
+    if ($RebuildExisting) {
+        $bakeArgs += "-RebuildExisting"
+    }
+
+    & powershell @bakeArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "[nav-pipeline] bake step failed"
+    }
+}
+
+if (-not $SkipSmoke) {
+    Write-Host "[nav-pipeline] STEP smoke: regression"
+    $smokeArgs = @(
+        "-ExecutionPolicy", "Bypass",
+        "-File", $smokeScript,
+        "-Executable", $Executable,
+        "-GameDirectory", $GameDirectory,
+        "-PerMapTimeoutSeconds", $PerMapTimeoutSeconds
+    )
+
+    if ($Maps.Count -gt 0) {
+        $smokeArgs += @("-Maps") + $Maps
+    }
+    if ($MapListFile) {
+        $smokeArgs += @("-MapListFile", $MapListFile)
+    }
+    if ($QueryPairsFile) {
+        $smokeArgs += @("-QueryPairsFile", $QueryPairsFile)
+    }
+    if ($ExpectedStatsFile) {
+        $smokeArgs += @("-ExpectedStatsFile", $ExpectedStatsFile)
+    }
+    if ($RequireQueryPairs) {
+        $smokeArgs += "-RequireQueryPairs"
+    }
+
+    & powershell @smokeArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "[nav-pipeline] smoke step failed"
+    }
+}
+
+if ($profileRequested -and $SkipSmoke) {
+    Write-Host "[nav-pipeline] profile dashboard skipped because smoke step was skipped"
+}
+
+if ($shouldRunProfileDashboard) {
+    Write-Host "[nav-pipeline] STEP profile: dashboard"
+    $profileArgs = @(
+        "-ExecutionPolicy", "Bypass",
+        "-File", $profileScript
+    )
+
+    if ($ProfileBudgetFile) {
+        $profileArgs += @("-BudgetFile", $ProfileBudgetFile)
+    }
+    if ($FailOnProfileBudget) {
+        $profileArgs += "-FailOnBudget"
+    }
+
+    & powershell @profileArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "[nav-pipeline] profile dashboard step failed"
+    }
+}
+
+Write-Host "[nav-pipeline] COMPLETE"
+exit 0

--- a/scripts/nav_profile_budget_example.csv
+++ b/scripts/nav_profile_budget_example.csv
@@ -1,0 +1,3 @@
+# map,max_world_gen_ms,max_inline_gen_ms,max_total_gen_ms,max_queue_frame_ms,max_queue_wait_avg_ms,max_detour_avg_ms,max_detour_points_after,max_over_budget_frames,min_world_tiles
+# Use map name or * for global defaults.
+*,2000,1000,2500,5,25,25,256,0,1

--- a/scripts/nav_profile_dashboard.ps1
+++ b/scripts/nav_profile_dashboard.ps1
@@ -1,0 +1,392 @@
+param(
+    [string]$LogsPath = "",
+    [string]$OutputCsv = "",
+    [string]$OutputMarkdown = "",
+    [string]$BudgetFile = "",
+    [switch]$FailOnBudget
+)
+
+$ErrorActionPreference = "Stop"
+
+function Parse-NullableDouble {
+    param(
+        [object]$Row,
+        [string]$Name
+    )
+
+    if (-not ($Row.PSObject.Properties.Name -contains $Name)) {
+        return $null
+    }
+
+    $raw = [string]$Row.$Name
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return $null
+    }
+
+    $value = 0.0
+    $ok = [double]::TryParse(
+        $raw,
+        [System.Globalization.NumberStyles]::Float,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [ref]$value
+    )
+    if (-not $ok) {
+        throw "Budget parse failed for '$Name': $raw"
+    }
+
+    return [double]$value
+}
+
+function Parse-NullableInt {
+    param(
+        [object]$Row,
+        [string]$Name
+    )
+
+    if (-not ($Row.PSObject.Properties.Name -contains $Name)) {
+        return $null
+    }
+
+    $raw = [string]$Row.$Name
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return $null
+    }
+
+    $value = 0
+    $ok = [int]::TryParse(
+        $raw,
+        [System.Globalization.NumberStyles]::Integer,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [ref]$value
+    )
+    if (-not $ok) {
+        throw "Budget parse failed for '$Name': $raw"
+    }
+
+    return [int]$value
+}
+
+function Get-BudgetRowForMap {
+    param(
+        [object[]]$BudgetRows,
+        [string]$Map
+    )
+
+    foreach ($row in $BudgetRows) {
+        if ($row.map -eq $Map) {
+            return $row
+        }
+    }
+
+    foreach ($row in $BudgetRows) {
+        if ($row.map -eq "*") {
+            return $row
+        }
+    }
+
+    return $null
+}
+
+function Parse-ProfileLog {
+    param(
+        [string]$LogPath
+    )
+
+    $logText = Get-Content -LiteralPath $LogPath -Raw
+
+    $head = [regex]::Match($logText, "backend=(\S+)\s+mesh_loaded=(\d+)\s+map=(\S+)")
+    if (-not $head.Success) {
+        return $null
+    }
+
+    $mesh = [regex]::Match($logText, "mesh world_tiles=(\d+)\s+inline_models=(\d+)\s+total_tiles=(\d+)\s+total_cells=(\d+)\s+total_layers=(\d+)\s+cell_size=([0-9.+-]+)\s+z_quant=([0-9.+-]+)\s+tile_size=(\d+)")
+    if (-not $mesh.Success) {
+        return $null
+    }
+
+    $generation = [regex]::Match($logText, "generation world_ms=([0-9.+-]+)\s+inline_ms=([0-9.+-]+)\s+total_ms=([0-9.+-]+)\s+generated_at_ms=(\d+)")
+    $worldGenLegacy = [regex]::Match($logText, "World mesh generation complete \(tile-first\) -\s+([0-9.+-]+)\s+ms")
+    $inlineGenLegacy = [regex]::Match($logText, "Inline models' navmesh generation complete -\s+([0-9.+-]+)\s+ms")
+    $totalGenLegacy = [regex]::Match($logText, "Overall generation time:\s+([0-9.+-]+)\s+ms")
+
+    $asyncQueue = [regex]::Match($logText, "async queue_depth=(\d+)\s+queue_peak=(\d+)\s+enqueued=(\d+)\s+refreshed=(\d+)\s+processed=(\d+)\s+completed=(\d+)\s+failed=(\d+)\s+cancelled=(\d+)\s+prepare_failures=(\d+)\s+expansions=(\d+)")
+    if (-not $asyncQueue.Success) {
+        return $null
+    }
+
+    $asyncWait = [regex]::Match($logText, "async wait_avg_ms=([0-9.+-]+)\s+wait_max_ms=(\d+)\s+wait_samples=(\d+)\s+frame_elapsed_ms=(\d+)\s+frame_processed=(\d+)\s+frame_expansions=(\d+)\s+budget_req=(\d+)\s+budget_expand=(\d+)\s+budget_queue_ms=([0-9.+-]+)\s+configured_queue_budget_ms=([0-9.+-]+)\s+over_budget_frames=(\d+)")
+    if (-not $asyncWait.Success) {
+        return $null
+    }
+    $backendDetour = [regex]::Match($logText, "backend detour_queries=(\d+)\s+detour_success=(\d+)\s+detour_failed=(\d+)\s+detour_avg_ms=([0-9.+-]+)\s+detour_max_ms=(\d+)\s+detour_points_before=(\d+)\s+detour_points_after=(\d+)")
+
+    $worldGenMs = 0.0
+    $inlineGenMs = 0.0
+    $totalGenMs = 0.0
+    $generatedAtMs = 0
+    $detourQueries = 0
+    $detourSuccess = 0
+    $detourFailed = 0
+    $detourAvgMs = 0.0
+    $detourMaxMs = 0
+    $detourPointsBefore = 0
+    $detourPointsAfter = 0
+
+    if ($generation.Success) {
+        $worldGenMs = [double]$generation.Groups[1].Value
+        $inlineGenMs = [double]$generation.Groups[2].Value
+        $totalGenMs = [double]$generation.Groups[3].Value
+        $generatedAtMs = [int64]$generation.Groups[4].Value
+    } else {
+        if ($worldGenLegacy.Success) { $worldGenMs = [double]$worldGenLegacy.Groups[1].Value }
+        if ($inlineGenLegacy.Success) { $inlineGenMs = [double]$inlineGenLegacy.Groups[1].Value }
+        if ($totalGenLegacy.Success) { $totalGenMs = [double]$totalGenLegacy.Groups[1].Value }
+    }
+    if ($backendDetour.Success) {
+        $detourQueries = [int]$backendDetour.Groups[1].Value
+        $detourSuccess = [int]$backendDetour.Groups[2].Value
+        $detourFailed = [int]$backendDetour.Groups[3].Value
+        $detourAvgMs = [double]$backendDetour.Groups[4].Value
+        $detourMaxMs = [int64]$backendDetour.Groups[5].Value
+        $detourPointsBefore = [int64]$backendDetour.Groups[6].Value
+        $detourPointsAfter = [int64]$backendDetour.Groups[7].Value
+    }
+
+    return [PSCustomObject]@{
+        log_path = $LogPath
+        log_timestamp = (Get-Item -LiteralPath $LogPath).LastWriteTimeUtc.ToString("o")
+        map = $head.Groups[3].Value
+        backend = $head.Groups[1].Value
+        mesh_loaded = [int]$head.Groups[2].Value
+
+        world_tiles = [int]$mesh.Groups[1].Value
+        inline_models = [int]$mesh.Groups[2].Value
+        total_tiles = [int]$mesh.Groups[3].Value
+        total_cells = [int]$mesh.Groups[4].Value
+        total_layers = [int]$mesh.Groups[5].Value
+        cell_size = [double]$mesh.Groups[6].Value
+        z_quant = [double]$mesh.Groups[7].Value
+        tile_size = [int]$mesh.Groups[8].Value
+
+        generation_world_ms = [double]$worldGenMs
+        generation_inline_ms = [double]$inlineGenMs
+        generation_total_ms = [double]$totalGenMs
+        generation_generated_at_ms = [int64]$generatedAtMs
+
+        async_queue_depth = [int]$asyncQueue.Groups[1].Value
+        async_queue_peak = [int]$asyncQueue.Groups[2].Value
+        async_enqueued = [int]$asyncQueue.Groups[3].Value
+        async_refreshed = [int]$asyncQueue.Groups[4].Value
+        async_processed = [int]$asyncQueue.Groups[5].Value
+        async_completed = [int]$asyncQueue.Groups[6].Value
+        async_failed = [int]$asyncQueue.Groups[7].Value
+        async_cancelled = [int]$asyncQueue.Groups[8].Value
+        async_prepare_failures = [int]$asyncQueue.Groups[9].Value
+        async_expansions = [int64]$asyncQueue.Groups[10].Value
+
+        async_wait_avg_ms = [double]$asyncWait.Groups[1].Value
+        async_wait_max_ms = [int64]$asyncWait.Groups[2].Value
+        async_wait_samples = [int]$asyncWait.Groups[3].Value
+        async_frame_elapsed_ms = [int64]$asyncWait.Groups[4].Value
+        async_frame_processed = [int]$asyncWait.Groups[5].Value
+        async_frame_expansions = [int]$asyncWait.Groups[6].Value
+        async_budget_requests = [int]$asyncWait.Groups[7].Value
+        async_budget_expansions = [int]$asyncWait.Groups[8].Value
+        async_budget_queue_ms = [double]$asyncWait.Groups[9].Value
+        async_budget_queue_configured_ms = [double]$asyncWait.Groups[10].Value
+        async_over_budget_frames = [int]$asyncWait.Groups[11].Value
+
+        detour_queries = [int]$detourQueries
+        detour_success = [int]$detourSuccess
+        detour_failed = [int]$detourFailed
+        detour_avg_ms = [double]$detourAvgMs
+        detour_max_ms = [int64]$detourMaxMs
+        detour_points_before = [int64]$detourPointsBefore
+        detour_points_after = [int64]$detourPointsAfter
+    }
+}
+
+function New-StatRow {
+    param(
+        [string]$Name,
+        [double[]]$Values
+    )
+
+    if (-not $Values -or $Values.Count -eq 0) {
+        return [PSCustomObject]@{
+            Metric = $Name
+            Min = ""
+            Avg = ""
+            Max = ""
+        }
+    }
+
+    $sum = 0.0
+    foreach ($v in $Values) {
+        $sum += $v
+    }
+
+    return [PSCustomObject]@{
+        Metric = $Name
+        Min = ("{0:N2}" -f (($Values | Measure-Object -Minimum).Minimum))
+        Avg = ("{0:N2}" -f ($sum / $Values.Count))
+        Max = ("{0:N2}" -f (($Values | Measure-Object -Maximum).Maximum))
+    }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if (-not $LogsPath) {
+    $LogsPath = Join-Path $repoRoot "build-nav/nav-regression-logs"
+}
+
+if (-not (Test-Path -LiteralPath $LogsPath)) {
+    throw "Logs path not found: $LogsPath"
+}
+
+if (-not $OutputCsv) {
+    $OutputCsv = Join-Path $LogsPath "nav_profile_dashboard.csv"
+}
+if (-not $OutputMarkdown) {
+    $OutputMarkdown = Join-Path $LogsPath "nav_profile_dashboard.md"
+}
+
+$logFiles = Get-ChildItem -LiteralPath $LogsPath -File -Filter "smoke_*.log" | Sort-Object LastWriteTimeUtc
+if ($logFiles.Count -eq 0) {
+    throw "No smoke logs found in: $LogsPath"
+}
+
+$allRows = New-Object System.Collections.Generic.List[object]
+foreach ($log in $logFiles) {
+    $row = Parse-ProfileLog -LogPath $log.FullName
+    if ($null -ne $row) {
+        $allRows.Add($row)
+    }
+}
+
+if ($allRows.Count -eq 0) {
+    throw "No parseable nav_profile_dump entries found in smoke logs."
+}
+
+$latestByMap = @($allRows `
+    | Group-Object map `
+    | ForEach-Object { $_.Group | Sort-Object log_timestamp -Descending | Select-Object -First 1 } `
+    | Sort-Object map)
+
+$latestByMap | Export-Csv -LiteralPath $OutputCsv -NoTypeInformation -Encoding UTF8
+
+$stats = New-Object System.Collections.Generic.List[object]
+$stats.Add((New-StatRow -Name "generation_total_ms" -Values @($latestByMap | ForEach-Object { [double]$_.generation_total_ms })))
+$stats.Add((New-StatRow -Name "generation_world_ms" -Values @($latestByMap | ForEach-Object { [double]$_.generation_world_ms })))
+$stats.Add((New-StatRow -Name "generation_inline_ms" -Values @($latestByMap | ForEach-Object { [double]$_.generation_inline_ms })))
+$stats.Add((New-StatRow -Name "async_wait_avg_ms" -Values @($latestByMap | ForEach-Object { [double]$_.async_wait_avg_ms })))
+$stats.Add((New-StatRow -Name "async_frame_elapsed_ms" -Values @($latestByMap | ForEach-Object { [double]$_.async_frame_elapsed_ms })))
+$stats.Add((New-StatRow -Name "world_tiles" -Values @($latestByMap | ForEach-Object { [double]$_.world_tiles })))
+$stats.Add((New-StatRow -Name "detour_avg_ms" -Values @($latestByMap | ForEach-Object { [double]$_.detour_avg_ms })))
+$stats.Add((New-StatRow -Name "detour_points_after" -Values @($latestByMap | ForEach-Object { [double]$_.detour_points_after })))
+
+$md = New-Object System.Collections.Generic.List[string]
+$md.Add("# Nav Profile Dashboard")
+$md.Add("")
+$md.Add(("Generated (UTC): {0}" -f (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss")))
+$md.Add("")
+$md.Add("## Per-map Latest")
+$md.Add("")
+$md.Add("| Map | Backend | World Tiles | Total Tiles | Gen Total ms | Queue Wait Avg ms | Queue Frame ms | Detour Avg ms | Detour Points After | Over Budget Frames |")
+$md.Add("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+foreach ($row in $latestByMap) {
+    $md.Add(("| {0} | {1} | {2} | {3} | {4:N2} | {5:N2} | {6} | {7:N2} | {8} | {9} |" -f `
+        $row.map,
+        $row.backend,
+        $row.world_tiles,
+        $row.total_tiles,
+        [double]$row.generation_total_ms,
+        [double]$row.async_wait_avg_ms,
+        [int64]$row.async_frame_elapsed_ms,
+        [double]$row.detour_avg_ms,
+        [int64]$row.detour_points_after,
+        [int]$row.async_over_budget_frames))
+}
+
+$md.Add("")
+$md.Add("## Aggregate")
+$md.Add("")
+$md.Add("| Metric | Min | Avg | Max |")
+$md.Add("| --- | ---: | ---: | ---: |")
+foreach ($s in $stats) {
+    $md.Add(("| {0} | {1} | {2} | {3} |" -f $s.Metric, $s.Min, $s.Avg, $s.Max))
+}
+
+$md | Set-Content -LiteralPath $OutputMarkdown -Encoding UTF8
+
+Write-Host ("[nav-profile] rows={0} maps={1}" -f $allRows.Count, $latestByMap.Count)
+Write-Host ("[nav-profile] csv={0}" -f $OutputCsv)
+Write-Host ("[nav-profile] md={0}" -f $OutputMarkdown)
+
+$violations = New-Object System.Collections.Generic.List[string]
+
+if ($BudgetFile) {
+    if (-not (Test-Path -LiteralPath $BudgetFile)) {
+        throw "Budget file not found: $BudgetFile"
+    }
+
+    $budgetRows = Import-Csv -LiteralPath $BudgetFile
+    foreach ($row in $latestByMap) {
+        $budget = Get-BudgetRowForMap -BudgetRows $budgetRows -Map $row.map
+        if ($null -eq $budget) {
+            continue
+        }
+
+        $maxWorldGenMs = Parse-NullableDouble -Row $budget -Name "max_world_gen_ms"
+        $maxInlineGenMs = Parse-NullableDouble -Row $budget -Name "max_inline_gen_ms"
+        $maxTotalGenMs = Parse-NullableDouble -Row $budget -Name "max_total_gen_ms"
+        $maxQueueFrameMs = Parse-NullableDouble -Row $budget -Name "max_queue_frame_ms"
+        $maxQueueWaitAvgMs = Parse-NullableDouble -Row $budget -Name "max_queue_wait_avg_ms"
+        $maxDetourAvgMs = Parse-NullableDouble -Row $budget -Name "max_detour_avg_ms"
+        $maxDetourPointsAfter = Parse-NullableInt -Row $budget -Name "max_detour_points_after"
+        $maxOverBudgetFrames = Parse-NullableInt -Row $budget -Name "max_over_budget_frames"
+        $minWorldTiles = Parse-NullableInt -Row $budget -Name "min_world_tiles"
+
+        if ($null -ne $maxWorldGenMs -and [double]$row.generation_world_ms -gt $maxWorldGenMs) {
+            $violations.Add(("{0}: generation_world_ms {1:N2} > budget {2:N2}" -f $row.map, [double]$row.generation_world_ms, $maxWorldGenMs))
+        }
+        if ($null -ne $maxInlineGenMs -and [double]$row.generation_inline_ms -gt $maxInlineGenMs) {
+            $violations.Add(("{0}: generation_inline_ms {1:N2} > budget {2:N2}" -f $row.map, [double]$row.generation_inline_ms, $maxInlineGenMs))
+        }
+        if ($null -ne $maxTotalGenMs -and [double]$row.generation_total_ms -gt $maxTotalGenMs) {
+            $violations.Add(("{0}: generation_total_ms {1:N2} > budget {2:N2}" -f $row.map, [double]$row.generation_total_ms, $maxTotalGenMs))
+        }
+        if ($null -ne $maxQueueFrameMs -and [double]$row.async_frame_elapsed_ms -gt $maxQueueFrameMs) {
+            $violations.Add(("{0}: async_frame_elapsed_ms {1} > budget {2:N2}" -f $row.map, [int64]$row.async_frame_elapsed_ms, $maxQueueFrameMs))
+        }
+        if ($null -ne $maxQueueWaitAvgMs -and [double]$row.async_wait_avg_ms -gt $maxQueueWaitAvgMs) {
+            $violations.Add(("{0}: async_wait_avg_ms {1:N2} > budget {2:N2}" -f $row.map, [double]$row.async_wait_avg_ms, $maxQueueWaitAvgMs))
+        }
+        if ($null -ne $maxDetourAvgMs -and [double]$row.detour_avg_ms -gt $maxDetourAvgMs) {
+            $violations.Add(("{0}: detour_avg_ms {1:N2} > budget {2:N2}" -f $row.map, [double]$row.detour_avg_ms, $maxDetourAvgMs))
+        }
+        if ($null -ne $maxDetourPointsAfter -and [int64]$row.detour_points_after -gt $maxDetourPointsAfter) {
+            $violations.Add(("{0}: detour_points_after {1} > budget {2}" -f $row.map, [int64]$row.detour_points_after, $maxDetourPointsAfter))
+        }
+        if ($null -ne $maxOverBudgetFrames -and [int]$row.async_over_budget_frames -gt $maxOverBudgetFrames) {
+            $violations.Add(("{0}: async_over_budget_frames {1} > budget {2}" -f $row.map, [int]$row.async_over_budget_frames, $maxOverBudgetFrames))
+        }
+        if ($null -ne $minWorldTiles -and [int]$row.world_tiles -lt $minWorldTiles) {
+            $violations.Add(("{0}: world_tiles {1} < budget minimum {2}" -f $row.map, [int]$row.world_tiles, $minWorldTiles))
+        }
+    }
+
+    if ($violations.Count -gt 0) {
+        Write-Host "[nav-profile][BUDGET] violations:"
+        foreach ($v in $violations) {
+            Write-Host ("  - {0}" -f $v)
+        }
+
+        if ($FailOnBudget) {
+            exit 1
+        }
+    } else {
+        Write-Host "[nav-profile][BUDGET] PASS"
+    }
+}
+
+exit 0

--- a/scripts/nav_query_pairs_example.csv
+++ b/scripts/nav_query_pairs_example.csv
@@ -1,0 +1,3 @@
+# map,id,start_x,start_y,start_z,goal_x,goal_y,goal_z,expect_found,expect_segments_ok
+# Populate with curated deterministic pairs for your content set.
+# q2dm1,q0,-128,64,24,512,256,24,1,1

--- a/scripts/nav_regression_smoke.ps1
+++ b/scripts/nav_regression_smoke.ps1
@@ -1,0 +1,338 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Executable,
+
+    [string[]]$Maps = @(),
+    [string]$MapListFile = "",
+
+    [string]$QueryPairsFile = "",
+    [string]$ExpectedStatsFile = "",
+    [switch]$RequireQueryPairs,
+
+    [string]$GameDirectory = "baseq2rtxp",
+    [int]$PerMapTimeoutSeconds = 120
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-MapList {
+    param(
+        [string[]]$InlineMaps,
+        [string]$MapFile
+    )
+
+    $result = New-Object System.Collections.Generic.List[string]
+
+    foreach ($map in $InlineMaps) {
+        $name = $map.Trim()
+        if ($name.Length -gt 0) {
+            $result.Add($name)
+        }
+    }
+
+    if ($MapFile -and (Test-Path -LiteralPath $MapFile)) {
+        foreach ($line in Get-Content -LiteralPath $MapFile) {
+            $trimmed = $line.Trim()
+            if ($trimmed.Length -eq 0) { continue }
+            if ($trimmed.StartsWith("#")) { continue }
+            $result.Add($trimmed)
+        }
+    }
+
+    return $result | Select-Object -Unique
+}
+
+function Get-QueryPairsByMap {
+    param(
+        [string]$QueryFile
+    )
+
+    $result = @{}
+    if (-not $QueryFile) {
+        return $result
+    }
+    if (-not (Test-Path -LiteralPath $QueryFile)) {
+        throw "QueryPairsFile not found: $QueryFile"
+    }
+
+    $lineNumber = 0
+    foreach ($line in Get-Content -LiteralPath $QueryFile) {
+        $lineNumber++
+        $trimmed = $line.Trim()
+        if ($trimmed.Length -eq 0) { continue }
+        if ($trimmed.StartsWith("#")) { continue }
+
+        $parts = $trimmed.Split(",")
+        if ($parts.Count -lt 9) {
+            throw ("Invalid query line {0}: expected at least 9 CSV columns" -f $lineNumber)
+        }
+
+        $map = $parts[0].Trim()
+        $id = $parts[1].Trim()
+        if (-not $map) {
+            throw ("Invalid query line {0}: missing map name" -f $lineNumber)
+        }
+        if (-not $id) {
+            $id = "q{0}" -f $lineNumber
+        }
+
+        try {
+            $query = [PSCustomObject]@{
+                Map = $map
+                Id = $id
+                StartX = [double]$parts[2].Trim()
+                StartY = [double]$parts[3].Trim()
+                StartZ = [double]$parts[4].Trim()
+                GoalX = [double]$parts[5].Trim()
+                GoalY = [double]$parts[6].Trim()
+                GoalZ = [double]$parts[7].Trim()
+                ExpectFound = [int]$parts[8].Trim()
+                ExpectSegmentsOk = if ($parts.Count -ge 10 -and $parts[9].Trim().Length -gt 0) { [int]$parts[9].Trim() } else { 1 }
+            }
+        }
+        catch {
+            throw ("Invalid query line {0}: numeric parse failed ({1})" -f $lineNumber, $_.Exception.Message)
+        }
+
+        if (-not $result.ContainsKey($map)) {
+            $result[$map] = New-Object System.Collections.Generic.List[object]
+        }
+        $result[$map].Add($query)
+    }
+
+    return $result
+}
+
+function Get-ExpectedWorldTiles {
+    param(
+        [string]$StatsFile
+    )
+
+    $result = @{}
+    if (-not $StatsFile) {
+        return $result
+    }
+    if (-not (Test-Path -LiteralPath $StatsFile)) {
+        throw "ExpectedStatsFile not found: $StatsFile"
+    }
+
+    $lineNumber = 0
+    foreach ($line in Get-Content -LiteralPath $StatsFile) {
+        $lineNumber++
+        $trimmed = $line.Trim()
+        if ($trimmed.Length -eq 0) { continue }
+        if ($trimmed.StartsWith("#")) { continue }
+
+        $parts = $trimmed.Split(",")
+        if ($parts.Count -lt 2) {
+            throw ("Invalid stats line {0}: expected CSV 'map,world_tiles'" -f $lineNumber)
+        }
+
+        $map = $parts[0].Trim()
+        if (-not $map) {
+            throw ("Invalid stats line {0}: missing map name" -f $lineNumber)
+        }
+
+        try {
+            $expectedWorldTiles = [int]$parts[1].Trim()
+        }
+        catch {
+            throw ("Invalid stats line {0}: world_tiles parse failed ({1})" -f $lineNumber, $_.Exception.Message)
+        }
+
+        $result[$map] = $expectedWorldTiles
+    }
+
+    return $result
+}
+
+function Format-InvariantDouble {
+    param(
+        [double]$Value
+    )
+
+    return $Value.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+if (-not (Test-Path -LiteralPath $Executable)) {
+    throw "Executable not found: $Executable"
+}
+
+$mapList = Get-MapList -InlineMaps $Maps -MapFile $MapListFile
+if ($mapList.Count -eq 0) {
+    throw "No maps provided. Use -Maps or -MapListFile."
+}
+
+$queriesByMap = Get-QueryPairsByMap -QueryFile $QueryPairsFile
+$expectedWorldTilesByMap = Get-ExpectedWorldTiles -StatsFile $ExpectedStatsFile
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$logRoot = Join-Path $repoRoot "build-nav/nav-regression-logs"
+New-Item -ItemType Directory -Path $logRoot -Force | Out-Null
+
+$failures = New-Object System.Collections.Generic.List[string]
+
+foreach ($map in $mapList) {
+    $logPath = Join-Path $logRoot ("smoke_{0}_{1:yyyyMMdd_HHmmss}.log" -f $map, (Get-Date))
+    Write-Host ("[nav-smoke] map={0}" -f $map)
+
+    $mapQueries = New-Object System.Collections.Generic.List[object]
+    if ($queriesByMap.ContainsKey($map)) {
+        foreach ($q in $queriesByMap[$map]) {
+            $mapQueries.Add($q)
+        }
+    }
+
+    if ($RequireQueryPairs -and $mapQueries.Count -eq 0) {
+        $failures.Add("$map (missing query pairs)")
+        Write-Host ("[nav-smoke][FAIL] map={0} no query pairs provided while -RequireQueryPairs is set" -f $map)
+        continue
+    }
+
+    $args = @(
+        "+set", "dedicated", "1",
+        "+set", "developer", "1",
+        "+set", "cheats", "1",
+        "+set", "game", $GameDirectory,
+        "+set", "nav_cache_auto_load", "0",
+        "+set", "nav_cache_auto_bake_missing", "0",
+        "+set", "nav_cache_auto_save_after_bake", "0",
+        "+map", $map,
+        "+sv", "nav_gen_voxelmesh",
+        "+sv", "nav_selftest", "256"
+    )
+
+    foreach ($query in $mapQueries) {
+        $args += @(
+            "+sv", "nav_query_path",
+            $query.Id,
+            (Format-InvariantDouble -Value $query.StartX),
+            (Format-InvariantDouble -Value $query.StartY),
+            (Format-InvariantDouble -Value $query.StartZ),
+            (Format-InvariantDouble -Value $query.GoalX),
+            (Format-InvariantDouble -Value $query.GoalY),
+            (Format-InvariantDouble -Value $query.GoalZ)
+        )
+    }
+
+    $args += @(
+        "+sv", "nav_profile_dump",
+        "+quit"
+    )
+
+    $proc = Start-Process -FilePath $Executable `
+        -ArgumentList $args `
+        -WorkingDirectory $repoRoot `
+        -RedirectStandardOutput $logPath `
+        -RedirectStandardError $logPath `
+        -PassThru
+
+    if (-not $proc.WaitForExit($PerMapTimeoutSeconds * 1000)) {
+        try { $proc.Kill() } catch {}
+        $failures.Add("$map (timeout)")
+        Write-Host ("[nav-smoke][FAIL] map={0} timed out ({1}s)" -f $map, $PerMapTimeoutSeconds)
+        continue
+    }
+
+    if ($proc.ExitCode -ne 0) {
+        $failures.Add("$map (exit $($proc.ExitCode))")
+        Write-Host ("[nav-smoke][FAIL] map={0} exited with code {1}" -f $map, $proc.ExitCode)
+        continue
+    }
+
+    if (-not (Test-Path -LiteralPath $logPath)) {
+        $failures.Add("$map (missing log)")
+        Write-Host ("[nav-smoke][FAIL] map={0} log file missing" -f $map)
+        continue
+    }
+
+    $logText = Get-Content -LiteralPath $logPath -Raw
+    if ($logText -notmatch "=== nav_profile_dump ===") {
+        $failures.Add("$map (no profile dump)")
+        Write-Host ("[nav-smoke][FAIL] map={0} missing nav_profile_dump output" -f $map)
+        continue
+    }
+
+    $selfTestMatch = [regex]::Match($logText, "\[nav-selftest\]\s+result=(PASS|FAIL)")
+    if (-not $selfTestMatch.Success -or $selfTestMatch.Groups[1].Value -ne "PASS") {
+        $failures.Add("$map (nav_selftest failed)")
+        Write-Host ("[nav-smoke][FAIL] map={0} nav_selftest missing or failed" -f $map)
+        continue
+    }
+
+    $meshLoadedMatch = [regex]::Match($logText, "mesh_loaded=(\d+)")
+    if (-not $meshLoadedMatch.Success -or $meshLoadedMatch.Groups[1].Value -ne "1") {
+        $failures.Add("$map (mesh not loaded)")
+        Write-Host ("[nav-smoke][FAIL] map={0} mesh_loaded check failed" -f $map)
+        continue
+    }
+
+    $worldTilesMatch = [regex]::Match($logText, "world_tiles=(\d+)")
+    if (-not $worldTilesMatch.Success) {
+        $failures.Add("$map (missing world_tiles)")
+        Write-Host ("[nav-smoke][FAIL] map={0} world_tiles metric missing" -f $map)
+        continue
+    }
+
+    $worldTiles = [int]$worldTilesMatch.Groups[1].Value
+    if ($worldTiles -le 0) {
+        $failures.Add("$map (world_tiles <= 0)")
+        Write-Host ("[nav-smoke][FAIL] map={0} world_tiles={1}" -f $map, $worldTiles)
+        continue
+    }
+
+    if ($expectedWorldTilesByMap.ContainsKey($map)) {
+        $expectedWorldTiles = [int]$expectedWorldTilesByMap[$map]
+        if ($worldTiles -ne $expectedWorldTiles) {
+            $failures.Add("$map (world_tiles mismatch expected=$expectedWorldTiles actual=$worldTiles)")
+            Write-Host ("[nav-smoke][FAIL] map={0} world_tiles expected {1} got {2}" -f $map, $expectedWorldTiles, $worldTiles)
+            continue
+        }
+    }
+
+    $queryFailure = $false
+    foreach ($query in $mapQueries) {
+        $pattern = "\[nav-query\]\s+id=" + [regex]::Escape($query.Id) + "\s+found=(\d+)\s+points=(\d+)\s+segments_ok=(\d+)\s+invalid_segment=(-?\d+)"
+        $m = [regex]::Match($logText, $pattern)
+        if (-not $m.Success) {
+            $failures.Add("$map (missing query result id=$($query.Id))")
+            Write-Host ("[nav-smoke][FAIL] map={0} missing nav-query result id={1}" -f $map, $query.Id)
+            $queryFailure = $true
+            break
+        }
+
+        $found = [int]$m.Groups[1].Value
+        $segmentsOk = [int]$m.Groups[3].Value
+        if ($found -ne [int]$query.ExpectFound) {
+            $failures.Add("$map (query id=$($query.Id) expect_found=$($query.ExpectFound) actual=$found)")
+            Write-Host ("[nav-smoke][FAIL] map={0} query={1} expected found={2} got {3}" -f $map, $query.Id, $query.ExpectFound, $found)
+            $queryFailure = $true
+            break
+        }
+
+        if ($found -eq 1 -and $segmentsOk -ne [int]$query.ExpectSegmentsOk) {
+            $failures.Add("$map (query id=$($query.Id) expect_segments_ok=$($query.ExpectSegmentsOk) actual=$segmentsOk)")
+            Write-Host ("[nav-smoke][FAIL] map={0} query={1} expected segments_ok={2} got {3}" -f $map, $query.Id, $query.ExpectSegmentsOk, $segmentsOk)
+            $queryFailure = $true
+            break
+        }
+    }
+    if ($queryFailure) {
+        continue
+    }
+
+    Write-Host ("[nav-smoke][OK] map={0} world_tiles={1} queries={2}" -f $map, $worldTiles, $mapQueries.Count)
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host ""
+    Write-Host ("[nav-smoke] FAILED: {0} map(s)" -f $failures.Count)
+    foreach ($f in $failures) {
+        Write-Host ("  - {0}" -f $f)
+    }
+    exit 1
+}
+
+Write-Host ""
+Write-Host ("[nav-smoke] SUCCESS: validated {0} map(s)" -f $mapList.Count)
+exit 0

--- a/src/baseq2rtxp/svgame/entities/monster/svg_monster_testdummy_puppet.cpp
+++ b/src/baseq2rtxp/svgame/entities/monster/svg_monster_testdummy_puppet.cpp
@@ -37,6 +37,8 @@
 
 // Navigation cluster routing (coarse tile routing pre-pass).
 #include "svgame/nav/svg_nav_clusters.h"
+// Reusable nav-agent orchestration helpers.
+#include "svgame/nav/svg_nav_agent.h"
 // Async navigation queue helpers.
 #include "svgame/nav/svg_nav_request.h"
 // Traversal helpers required for path invalidation.
@@ -195,23 +197,7 @@ void SVG_TestDummy_ResetNavPath( svg_monster_testdummy_t *self ) {
         return;
     }
 
-    /**
-    *    Cancel any pending async request so we do not reuse stale results.
-    **/
-    if ( self->navPathProcess.pending_request_handle > 0 ) {
-        SVG_Nav_CancelRequest( self->navPathProcess.pending_request_handle );
-    }
-
-    /**
-    *    Clear cached path buffers and reset traversal bookkeeping.
-    **/
-    SVG_Nav_FreeTraversalPath( &self->navPathProcess.path );
-    self->navPathProcess.path_index = 0;
-    self->navPathProcess.path_goal = {};
-    self->navPathProcess.path_start = {};
-    self->navPathProcess.path_center_offset_z = 0.0f;
-    self->navPathProcess.rebuild_in_progress = false;
-    self->navPathProcess.pending_request_handle = 0;
+    SVG_NavAgent_ResetPathProcess( &self->navPathProcess );
 }
 
 /**
@@ -230,102 +216,9 @@ void SVG_TestDummy_ResetNavPath( svg_monster_testdummy_t *self ) {
 bool SVG_TestDummy_TryQueueNavRebuild( svg_monster_testdummy_t *self, const Vector3 &start_origin,
     const Vector3 &goal_origin, const svg_nav_path_policy_t &policy, const Vector3 &agent_mins,
     const Vector3 &agent_maxs, const bool force = false ) {
-    /**
-    *    @brief	Attempt to enqueue an asynchronous navigation rebuild for this entity.
-    *    @note	Lightweight diagnostic logging is emitted when DUMMY_NAV_DEBUG is enabled
-    *
-    *    Guard: only enqueue when the async queue mode is explicitly enabled.
-    **/
-    if ( !self || !nav_nav_async_queue_mode || nav_nav_async_queue_mode->integer == 0 ) {
-        if ( DUMMY_NAV_DEBUG ) {
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: async queue mode disabled, cannot enqueue. ent=%d\n", self ? self->s.number : -1 );
-        }
-        return false;
-    }
-
-    if ( !SVG_Nav_IsAsyncNavEnabled() ) {
-        if ( DUMMY_NAV_DEBUG ) {
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: async nav globally disabled, ent=%d\n", self->s.number );
-        }
-        return false;
-    }
-
-    /**
-    *    Throttle guard:
-    *        If the path process is not allowed to rebuild yet, skip enqueuing and
-    *        let callers keep following the current path without forcing sync rebuilds.
-    **/
-    // Force bypass ensures explicit breadcrumb goals always queue new work.
-    if ( !force && !self->navPathProcess.CanRebuild( policy ) ) {
-        // Movement throttled/backoff prevents enqueuing now; callers should keep using current path.
-        if ( DUMMY_NAV_DEBUG ) {
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: CanRebuild() == false, throttled/backoff. ent=%d next_rebuild=%lld backoff_until=%lld\n",
-                self->s.number, ( long long )self->navPathProcess.next_rebuild_time.Milliseconds(), ( long long )self->navPathProcess.backoff_until.Milliseconds() );
-        }
-        return true;
-    }
-
-    /**
-    *    Movement heuristic:
-    *        Only queue rebuilds when the path process thinks goal/start movement
-    *        warrants it; this prevents re-queueing every frame for static goals.
-    **/
-    const bool movementWarrantsRebuild =
-        self->navPathProcess.ShouldRebuildForGoal2D( goal_origin, policy )
-        || self->navPathProcess.ShouldRebuildForGoal3D( goal_origin, policy )
-        || self->navPathProcess.ShouldRebuildForStart2D( start_origin, policy )
-        || self->navPathProcess.ShouldRebuildForStart3D( start_origin, policy );
-    // Force bypass ensures explicit breadcrumb goals bypass movement heuristics.
-    if ( !force && !movementWarrantsRebuild ) {
-        if ( DUMMY_NAV_DEBUG ) {
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: movement does not warrant rebuild, ent=%d\n", self->s.number );
-        }
-        return true;
-    }
-
-    /**
-    *    Guard: avoid redundant requests when one is already pending for this process.
-    **/
-    if ( SVG_Nav_IsRequestPending( &self->navPathProcess ) ) {
-        if ( DUMMY_NAV_DEBUG ) {
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: request already pending for ent=%d\n", self->s.number );
-        }
-        return true;
-    }
-
-    /**
-    *\tEnqueue the rebuild request and record the handle for diagnostics.
-    **/
-    const nav_request_handle_t handle = SVG_Nav_RequestPathAsync( &self->navPathProcess, start_origin, goal_origin, policy, agent_mins, agent_maxs, force );
-    if ( handle <= 0 ) {
-        if ( DUMMY_NAV_DEBUG ) {
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: enqueue failed (handle=%d) ent=%d\n", handle, self->s.number );
-        }
-        return false;
-    }
-
-    // Record that a rebuild is in progress for diagnostics and possible cancellation.
-    self->navPathProcess.rebuild_in_progress = true;
-    self->navPathProcess.pending_request_handle = handle;
-    if ( DUMMY_NAV_DEBUG ) {
-        gi.dprintf( "[DEBUG] TryQueueNavRebuild: queued rebuild handle=%d ent=%d force=%d\n", handle, self->s.number, force ? 1 : 0 );
-        // Also print the converted nav-center origins so we can correlate node resolution.
-        const nav_mesh_t *mesh = g_nav_mesh.get();
-        if ( mesh ) {
-            const Vector3 start_center = SVG_Nav_ConvertFeetToCenter( mesh, start_origin, &agent_mins, &agent_maxs );
-            const Vector3 goal_center = SVG_Nav_ConvertFeetToCenter( mesh, goal_origin, &agent_mins, &agent_maxs );
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: start=(%.1f %.1f %.1f) start_center=(%.1f %.1f %.1f) goal=(%.1f %.1f %.1f) goal_center=(%.1f %.1f %.1f)\n",
-                start_origin.x, start_origin.y, start_origin.z,
-                start_center.x, start_center.y, start_center.z,
-                goal_origin.x, goal_origin.y, goal_origin.z,
-                goal_center.x, goal_center.y, goal_center.z );
-        } else {
-            gi.dprintf( "[DEBUG] TryQueueNavRebuild: start=(%.1f %.1f %.1f) goal=(%.1f %.1f %.1f) (no mesh)\n",
-                start_origin.x, start_origin.y, start_origin.z,
-                goal_origin.x, goal_origin.y, goal_origin.z );
-        }
-    }
-    return true;
+    return self
+        && SVG_NavAgent_TryQueueRebuild( &self->navPathProcess, self->s.number,
+            start_origin, goal_origin, policy, agent_mins, agent_maxs, force, DUMMY_NAV_DEBUG );
 }
 
 // -----------------------------------------------------------------

--- a/src/baseq2rtxp/svgame/nav/README.md
+++ b/src/baseq2rtxp/svgame/nav/README.md
@@ -148,6 +148,8 @@ The navigation system now exposes traversal helpers for A* pathfinding:
 - `SVG_Nav_GenerateTraversalPathForOrigin` builds a waypoint list between a start and goal.
 - `SVG_Nav_QueryMovementDirection` returns a normalized direction toward the next waypoint.
 - `SVG_Nav_FreeTraversalPath` releases path memory.
+- `SVG_NavAgent_TryQueueRebuild` standardizes async path rebuild orchestration for AI entities.
+- `SVG_NavAgent_ResetPathProcess` provides shared cancel/reset behavior for AI nav components.
 
 Example output:
 ```

--- a/src/baseq2rtxp/svgame/nav/svg_nav.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav.cpp
@@ -23,6 +23,9 @@
 #include "common/bsp.h"
 #include "common/files.h"
 
+#include <algorithm>
+#include <cctype>
+#include <cmath>
 
 
 
@@ -85,6 +88,60 @@ void SVG_Nav_Log( const char *fmt, ... ) {
 	gi.dprintf( "%s", buf );
 }
 
+nav_rigid_xform_t SVG_Nav_BuildRigidXform( const Vector3 &origin, const Vector3 &angles ) {
+	nav_rigid_xform_t xform = {};
+	xform.origin = origin;
+
+	Vector3 forward = {};
+	Vector3 right = {};
+	Vector3 up = {};
+	QM_AngleVectors( angles, &forward, &right, &up );
+
+	xform.forward = forward;
+	xform.side = {
+		-right[ 0 ],
+		-right[ 1 ],
+		-right[ 2 ]
+	};
+	xform.up = up;
+	return xform;
+}
+
+Vector3 SVG_Nav_WorldFromLocal( const nav_rigid_xform_t &xform, const Vector3 &local_point ) {
+	const Vector3 world_offset = {
+		( local_point[ 0 ] * xform.forward[ 0 ] ) + ( local_point[ 1 ] * xform.side[ 0 ] ) + ( local_point[ 2 ] * xform.up[ 0 ] ),
+		( local_point[ 0 ] * xform.forward[ 1 ] ) + ( local_point[ 1 ] * xform.side[ 1 ] ) + ( local_point[ 2 ] * xform.up[ 1 ] ),
+		( local_point[ 0 ] * xform.forward[ 2 ] ) + ( local_point[ 1 ] * xform.side[ 2 ] ) + ( local_point[ 2 ] * xform.up[ 2 ] )
+	};
+
+	return QM_Vector3Add( xform.origin, world_offset );
+}
+
+Vector3 SVG_Nav_LocalFromWorld( const nav_rigid_xform_t &xform, const Vector3 &world_point ) {
+	const Vector3 delta = QM_Vector3Subtract( world_point, xform.origin );
+	return {
+		QM_Vector3DotProduct( delta, xform.forward ),
+		QM_Vector3DotProduct( delta, xform.side ),
+		QM_Vector3DotProduct( delta, xform.up )
+	};
+}
+
+Vector3 SVG_Nav_WorldDirectionFromLocal( const nav_rigid_xform_t &xform, const Vector3 &local_dir ) {
+	return {
+		( local_dir[ 0 ] * xform.forward[ 0 ] ) + ( local_dir[ 1 ] * xform.side[ 0 ] ) + ( local_dir[ 2 ] * xform.up[ 0 ] ),
+		( local_dir[ 0 ] * xform.forward[ 1 ] ) + ( local_dir[ 1 ] * xform.side[ 1 ] ) + ( local_dir[ 2 ] * xform.up[ 1 ] ),
+		( local_dir[ 0 ] * xform.forward[ 2 ] ) + ( local_dir[ 1 ] * xform.side[ 2 ] ) + ( local_dir[ 2 ] * xform.up[ 2 ] )
+	};
+}
+
+Vector3 SVG_Nav_LocalDirectionFromWorld( const nav_rigid_xform_t &xform, const Vector3 &world_dir ) {
+	return {
+		QM_Vector3DotProduct( world_dir, xform.forward ),
+		QM_Vector3DotProduct( world_dir, xform.side ),
+		QM_Vector3DotProduct( world_dir, xform.up )
+	};
+}
+
 /**
  *    @brief    Convert a caller-provided feet-origin into nav-center space.
  *    @note     Helper implementation for `SVG_Nav_ConvertFeetToCenter` declared in header.
@@ -104,6 +161,20 @@ const Vector3 SVG_Nav_ConvertFeetToCenter( const nav_mesh_t *mesh, const Vector3
     // Apply only Z offset; XY remain unchanged.
 	Vector3 out = feet_origin;
 	out[ 2 ] += centerOffsetZ;
+	return out;
+}
+
+const Vector3 SVG_Nav_ConvertCenterToFeet( const nav_mesh_t *mesh, const Vector3 &center_origin, const Vector3 *agent_mins, const Vector3 *agent_maxs ) {
+	if ( !mesh ) {
+		return center_origin;
+	}
+
+	const Vector3 &mins = agent_mins ? *agent_mins : mesh->agent_mins;
+	const Vector3 &maxs = agent_maxs ? *agent_maxs : mesh->agent_maxs;
+	const float centerOffsetZ = ( mins.z + maxs.z ) * 0.5f;
+
+	Vector3 out = center_origin;
+	out[ 2 ] -= centerOffsetZ;
 	return out;
 }
 
@@ -305,6 +376,126 @@ bool SVG_Nav_Occupancy_Blocked( const nav_mesh_t *mesh, int32_t tileId, int32_t 
 }
 
 /**
+*    @brief    Query occupancy soft-cost for a nav-center world position.
+*/
+int32_t SVG_Nav_Occupancy_SoftCostForPosition( const nav_mesh_t *mesh, const Vector3 &position, bool allow_fallback ) {
+	if ( !mesh ) {
+		return 0;
+	}
+
+	nav_node_ref_t node = {};
+	if ( !Nav_FindNodeForPosition( mesh, position, position.z, &node, allow_fallback ) ) {
+		return 0;
+	}
+
+	return SVG_Nav_Occupancy_SoftCost( mesh, node.key.tile_index, node.key.cell_index, node.key.layer_index );
+}
+
+/**
+*    @brief    Query occupancy blocked-flag for a nav-center world position.
+*/
+bool SVG_Nav_Occupancy_BlockedForPosition( const nav_mesh_t *mesh, const Vector3 &position, bool allow_fallback ) {
+	if ( !mesh ) {
+		return false;
+	}
+
+	nav_node_ref_t node = {};
+	if ( !Nav_FindNodeForPosition( mesh, position, position.z, &node, allow_fallback ) ) {
+		return false;
+	}
+
+	return SVG_Nav_Occupancy_Blocked( mesh, node.key.tile_index, node.key.cell_index, node.key.layer_index );
+}
+
+/**
+*    @brief    Determine whether an entity should contribute to dynamic occupancy.
+*/
+static inline bool Nav_IsDynamicOccupancyActor( const svg_base_edict_t *ent ) {
+	if ( !ent || !ent->inUse ) {
+		return false;
+	}
+
+	// Use players + live monsters as dynamic crowd actors.
+	const bool isClientActor = ( ent->client != nullptr ) && ent->health > 0;
+	const bool isMonsterActor = ( ( ent->svFlags & SVF_MONSTER ) != 0 || ent->s.entityType == ET_MONSTER ) && ent->health > 0;
+	if ( !isClientActor && !isMonsterActor ) {
+		return false;
+	}
+
+	// Unlinked actors are not participating in the world this frame.
+	if ( !ent->area.prev ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+*    @brief    Populate dynamic occupancy from active actors for the current frame.
+*/
+void SVG_Nav_Occupancy_PopulateFromEntities( void ) {
+	nav_mesh_t *mesh = g_nav_mesh.get();
+	if ( !mesh ) {
+		return;
+	}
+
+	// Always reset per-frame occupancy, even when disabled, to avoid stale influence.
+	SVG_Nav_Occupancy_Clear( mesh );
+	if ( !nav_occupancy_enable || nav_occupancy_enable->integer == 0 ) {
+		return;
+	}
+	if ( !globals.edictPool ) {
+		return;
+	}
+
+	const int32_t baseSoftCost = std::max( 1, nav_occupancy_actor_soft_cost ? nav_occupancy_actor_soft_cost->integer : 2 );
+	const int32_t footprintPadCells = std::max( 0, nav_occupancy_actor_footprint_pad_cells ? nav_occupancy_actor_footprint_pad_cells->integer : 0 );
+	const double cellSize = std::max( 0.001, mesh->cell_size_xy );
+
+	for ( int32_t i = 1; i < globals.edictPool->num_edicts; ++i ) {
+		svg_base_edict_t *ent = g_edict_pool.EdictForNumber( i );
+		if ( !Nav_IsDynamicOccupancyActor( ent ) ) {
+			continue;
+		}
+
+		const Vector3 navCenterOrigin = SVG_Nav_ConvertFeetToCenter( mesh, ent->currentOrigin, &mesh->agent_mins, &mesh->agent_maxs );
+
+		nav_node_ref_t originNode = {};
+		if ( !Nav_FindNodeForPosition( mesh, navCenterOrigin, navCenterOrigin.z, &originNode, true ) ) {
+			continue;
+		}
+
+		SVG_Nav_Occupancy_Add( mesh, originNode.key.tile_index, originNode.key.cell_index, originNode.key.layer_index, baseSoftCost, false );
+
+		// Stamp nearby cells based on actor footprint so occupancy is not a single-point artifact.
+		const float halfX = std::max( std::fabs( ent->mins.x ), std::fabs( ent->maxs.x ) );
+		const float halfY = std::max( std::fabs( ent->mins.y ), std::fabs( ent->maxs.y ) );
+		const int32_t radiusX = std::max( 0, ( int32_t )std::ceil( ( double )halfX / cellSize ) + footprintPadCells );
+		const int32_t radiusY = std::max( 0, ( int32_t )std::ceil( ( double )halfY / cellSize ) + footprintPadCells );
+		const int32_t neighborSoftCost = std::max( 1, baseSoftCost - 1 );
+
+		for ( int32_t dy = -radiusY; dy <= radiusY; ++dy ) {
+			for ( int32_t dx = -radiusX; dx <= radiusX; ++dx ) {
+				if ( dx == 0 && dy == 0 ) {
+					continue;
+				}
+
+				Vector3 samplePos = originNode.position;
+				samplePos.x += ( float )( dx * mesh->cell_size_xy );
+				samplePos.y += ( float )( dy * mesh->cell_size_xy );
+
+				nav_node_ref_t sampleNode = {};
+				if ( !Nav_FindNodeForPosition( mesh, samplePos, originNode.position.z, &sampleNode, true ) ) {
+					continue;
+				}
+
+				SVG_Nav_Occupancy_Add( mesh, sampleNode.key.tile_index, sampleNode.key.cell_index, sampleNode.key.layer_index, neighborSoftCost, false );
+			}
+		}
+	}
+}
+
+/**
 *   @brief  Navigation CVars for generation parameters.
 **/
 //! XY grid cell size in world units.
@@ -349,6 +540,15 @@ cvar_t *nav_cost_slope_weight = nullptr;
 cvar_t *nav_cost_drop_weight = nullptr;
 cvar_t *nav_cost_goal_z_blend_factor = nullptr;
 cvar_t *nav_cost_min_cost_per_unit = nullptr;
+cvar_t *nav_occupancy_enable = nullptr;
+cvar_t *nav_occupancy_actor_soft_cost = nullptr;
+cvar_t *nav_occupancy_actor_footprint_pad_cells = nullptr;
+cvar_t *nav_multi_agent_mode = nullptr;
+cvar_t *nav_cache_auto_load = nullptr;
+cvar_t *nav_cache_auto_bake_missing = nullptr;
+cvar_t *nav_cache_auto_save_after_bake = nullptr;
+cvar_t *nav_cache_require_hash_match = nullptr;
+cvar_t *nav_path_backend = nullptr;
 
 
 
@@ -370,6 +570,37 @@ static inline void Nav_SetPresenceBit( nav_tile_t *tile, int32_t cell_index ) {
 	const int32_t word_index = cell_index >> 5;
 	const int32_t bit_index = cell_index & 31;
 	tile->presence_bits[ word_index ] |= ( 1u << bit_index );
+}
+
+/**
+*   @brief  Build `<mapname>.vans` for cache load/save operations.
+**/
+bool SVG_Nav_BuildDefaultCacheFilename( char *outFilename, size_t outSize ) {
+	if ( !outFilename || outSize == 0 ) {
+		return false;
+	}
+
+	outFilename[ 0 ] = '\0';
+	if ( !level.mapname[ 0 ] ) {
+		return false;
+	}
+
+	char mapName[ 64 ] = {};
+	Q_strlcpy( mapName, level.mapname, sizeof( mapName ) );
+	for ( char &ch : mapName ) {
+		if ( ch == '\0' ) {
+			break;
+		}
+
+		const unsigned char uch = (unsigned char)ch;
+		if ( std::isalnum( uch ) || ch == '_' || ch == '-' ) {
+			continue;
+		}
+		ch = '_';
+	}
+
+	const size_t written = Q_snprintf( outFilename, outSize, "%s.vans", mapName );
+	return written > 0 && written < outSize;
 }
 
 
@@ -495,6 +726,19 @@ void SVG_Nav_Init( void ) {
 	nav_cost_drop_weight = gi.cvar( "nav_cost_drop_weight", "4.0", 0 );
 	nav_cost_goal_z_blend_factor = gi.cvar( "nav_cost_goal_z_blend_factor", "0.5", 0 );
 	nav_cost_min_cost_per_unit = gi.cvar( "nav_cost_min_cost_per_unit", "1.0", 0 );
+
+	/**
+	*   Dynamic occupancy tuning CVars:
+	*/
+	nav_occupancy_enable = gi.cvar( "nav_occupancy_enable", "1", 0 );
+	nav_occupancy_actor_soft_cost = gi.cvar( "nav_occupancy_actor_soft_cost", "2", 0 );
+	nav_occupancy_actor_footprint_pad_cells = gi.cvar( "nav_occupancy_actor_footprint_pad_cells", "1", 0 );
+	nav_multi_agent_mode = gi.cvar( "nav_multi_agent_mode", "0", 0 );
+	nav_cache_auto_load = gi.cvar( "nav_cache_auto_load", "1", 0 );
+	nav_cache_auto_bake_missing = gi.cvar( "nav_cache_auto_bake_missing", "0", 0 );
+	nav_cache_auto_save_after_bake = gi.cvar( "nav_cache_auto_save_after_bake", "1", 0 );
+	nav_cache_require_hash_match = gi.cvar( "nav_cache_require_hash_match", "1", 0 );
+	nav_path_backend = gi.cvar( "nav_path_backend", "0", 0 );
 
 	/**
 	*    Register async nav request queue cvars.
@@ -699,6 +943,52 @@ nav_agent_profile_t SVG_Nav_BuildAgentProfileFromCvars( void ) {
 	profile.max_slope_deg = nav_max_slope_deg ? nav_max_slope_deg->value : default_slope;
 
 	return profile;
+}
+
+/**
+*   @brief  Validate that an agent bbox is strictly increasing on all axes.
+**/
+bool SVG_Nav_IsAgentBoundsValid( const Vector3 &mins, const Vector3 &maxs ) {
+	return maxs.x > mins.x
+		&& maxs.y > mins.y
+		&& maxs.z > mins.z;
+}
+
+/**
+*   @brief  Resolve runtime agent profile for path requests.
+**/
+nav_agent_profile_t SVG_Nav_ResolveAgentProfile( const nav_mesh_t *mesh, const Vector3 *requested_mins, const Vector3 *requested_maxs ) {
+	nav_agent_profile_t resolved = SVG_Nav_BuildAgentProfileFromCvars();
+
+	const bool hasRequested = requested_mins && requested_maxs;
+	const bool requestedValid = hasRequested && SVG_Nav_IsAgentBoundsValid( *requested_mins, *requested_maxs );
+	const bool meshValid = mesh && SVG_Nav_IsAgentBoundsValid( mesh->agent_mins, mesh->agent_maxs );
+	const bool multiAgentEnabled = nav_multi_agent_mode && nav_multi_agent_mode->integer != 0;
+
+	if ( multiAgentEnabled && requestedValid ) {
+		resolved.mins = *requested_mins;
+		resolved.maxs = *requested_maxs;
+		return resolved;
+	}
+
+	if ( meshValid ) {
+		resolved.mins = mesh->agent_mins;
+		resolved.maxs = mesh->agent_maxs;
+		if ( mesh->max_step > 0.0 ) {
+			resolved.max_step_height = mesh->max_step;
+		}
+		if ( mesh->max_slope_deg > 0.0 ) {
+			resolved.max_slope_deg = mesh->max_slope_deg;
+		}
+		return resolved;
+	}
+
+	if ( requestedValid ) {
+		resolved.mins = *requested_mins;
+		resolved.maxs = *requested_maxs;
+	}
+
+	return resolved;
 }
 /**
 *   @brief  Check if a surface normal is walkable based on slope.

--- a/src/baseq2rtxp/svgame/nav/svg_nav.h
+++ b/src/baseq2rtxp/svgame/nav/svg_nav.h
@@ -177,6 +177,46 @@ typedef struct nav_inline_model_runtime_s {
 } nav_inline_model_runtime_t;
 
 /**
+*   @brief  Rigid transform basis used for inline-model local/world conversions.
+*   @note   Uses Quake-style angle basis where local +Y maps to `-right`.
+**/
+typedef struct nav_rigid_xform_s {
+	//! World-space translation.
+	Vector3 origin;
+	//! Local +X axis in world space.
+	Vector3 forward;
+	//! Local +Y axis in world space (already negated from AngleVectors right).
+	Vector3 side;
+	//! Local +Z axis in world space.
+	Vector3 up;
+} nav_rigid_xform_t;
+
+/**
+*   @brief  Build a rigid transform from entity origin + Euler angles.
+**/
+nav_rigid_xform_t SVG_Nav_BuildRigidXform( const Vector3 &origin, const Vector3 &angles );
+
+/**
+*   @brief  Transform a local-space point into world-space.
+**/
+Vector3 SVG_Nav_WorldFromLocal( const nav_rigid_xform_t &xform, const Vector3 &local_point );
+
+/**
+*   @brief  Transform a world-space point into local-space.
+**/
+Vector3 SVG_Nav_LocalFromWorld( const nav_rigid_xform_t &xform, const Vector3 &world_point );
+
+/**
+*   @brief  Transform a local-space direction into world-space (no translation).
+**/
+Vector3 SVG_Nav_WorldDirectionFromLocal( const nav_rigid_xform_t &xform, const Vector3 &local_dir );
+
+/**
+*   @brief  Transform a world-space direction into local-space (no translation).
+**/
+Vector3 SVG_Nav_LocalDirectionFromWorld( const nav_rigid_xform_t &xform, const Vector3 &world_dir );
+
+/**
 *	Navigation Cluster Graph (Tile-Level):
 *
 *	This is a coarse adjacency graph over world tiles. It is built after voxelmesh
@@ -228,6 +268,9 @@ struct nav_tile_cluster_graph_t {
 	std::vector<nav_tile_cluster_node_t> nodes;
 };
 
+// Forward declaration; full definition appears below.
+struct nav_mesh_s;
+
 /**
 *	@brief	Refreshes inline model runtime transforms (for movers).
 *	@note	Intended to be cheap enough to call once per frame.
@@ -240,6 +283,21 @@ void SVG_Nav_RefreshInlineModelRuntime( void );
 *   @return Populated nav_agent_profile_t describing hull extents and traversal constraints.
 **/
 nav_agent_profile_t SVG_Nav_BuildAgentProfileFromCvars( void );
+
+/**
+*   @brief  Validate that an agent bbox has strictly increasing extents on all axes.
+**/
+bool SVG_Nav_IsAgentBoundsValid( const Vector3 &mins, const Vector3 &maxs );
+
+/**
+*   @brief  Resolve runtime agent profile for navigation queries.
+*   @param  mesh             Current nav mesh (optional).
+*   @param  requested_mins   Optional per-request mins override.
+*   @param  requested_maxs   Optional per-request maxs override.
+*   @note   Honors `nav_multi_agent_mode` when deciding whether to keep caller-supplied
+*           bounds or force mesh-authored bounds for strict compatibility.
+**/
+nav_agent_profile_t SVG_Nav_ResolveAgentProfile( const nav_mesh_s *mesh, const Vector3 *requested_mins = nullptr, const Vector3 *requested_maxs = nullptr );
 
 /**
 *    @brief    Runtime occupancy entry used for dynamic blocking/penalties.
@@ -338,6 +396,14 @@ typedef struct nav_mesh_s {
     int32_t total_xy_cells;
     //! Total number of Z layers across all cells.
     int32_t total_layers;
+    //! Last world-generation phase duration in milliseconds.
+    double profile_world_gen_ms = 0.0;
+    //! Last inline-model-generation phase duration in milliseconds.
+    double profile_inline_gen_ms = 0.0;
+    //! Last full generation duration in milliseconds.
+    double profile_total_gen_ms = 0.0;
+    //! Real-system timestamp (ms) when generation metrics were recorded.
+    uint64_t profile_generated_at_ms = 0;
 } nav_mesh_t;
 
 /**
@@ -389,6 +455,30 @@ int32_t SVG_Nav_Occupancy_SoftCost( const nav_mesh_t *mesh, int32_t tileId, int3
 *	@return	True if blocked.
 */
 bool SVG_Nav_Occupancy_Blocked( const nav_mesh_t *mesh, int32_t tileId, int32_t cellIndex, int32_t layerIndex );
+
+/**
+*	@brief	Query occupancy soft-cost at a world/nav-center position.
+*	@param	mesh	Navigation mesh.
+*	@param	position	Position in nav-center space.
+*	@param	allow_fallback	Whether node lookup fallback is allowed.
+*	@return	Soft cost at the resolved node (0 if unresolved).
+**/
+int32_t SVG_Nav_Occupancy_SoftCostForPosition( const nav_mesh_t *mesh, const Vector3 &position, bool allow_fallback = true );
+
+/**
+*	@brief	Query occupancy blocked flag at a world/nav-center position.
+*	@param	mesh	Navigation mesh.
+*	@param	position	Position in nav-center space.
+*	@param	allow_fallback	Whether node lookup fallback is allowed.
+*	@return	True if the resolved node is currently blocked.
+**/
+bool SVG_Nav_Occupancy_BlockedForPosition( const nav_mesh_t *mesh, const Vector3 &position, bool allow_fallback = true );
+
+/**
+*	@brief	Populate dynamic occupancy from active actors for the current frame.
+*	@note	Called once per server frame before async request processing.
+**/
+void SVG_Nav_Occupancy_PopulateFromEntities( void );
 
 /**
 *   @brief  Path result for navigation traversal queries.
@@ -451,6 +541,15 @@ extern cvar_t *nav_cost_slope_weight;
 extern cvar_t *nav_cost_drop_weight;
 extern cvar_t *nav_cost_goal_z_blend_factor;
 extern cvar_t *nav_cost_min_cost_per_unit;
+extern cvar_t *nav_occupancy_enable;
+extern cvar_t *nav_occupancy_actor_soft_cost;
+extern cvar_t *nav_occupancy_actor_footprint_pad_cells;
+extern cvar_t *nav_multi_agent_mode;
+extern cvar_t *nav_cache_auto_load;
+extern cvar_t *nav_cache_auto_bake_missing;
+extern cvar_t *nav_cache_auto_save_after_bake;
+extern cvar_t *nav_cache_require_hash_match;
+extern cvar_t *nav_path_backend;
 
 /**
  *  @brief  Profiling and logging control CVars.
@@ -499,6 +598,50 @@ void SVG_Nav_Log( const char *fmt, ... );
 *   @return True if the slope is walkable, false otherwise.
 **/
 const bool IsWalkableSlope( const Vector3 &normal, double max_slope_deg );
+
+/**
+*   @brief  Build the default nav-cache filename for the active map.
+*   @param  outFilename Destination buffer for `<mapname>.vans`.
+*   @param  outSize     Size of destination buffer.
+*   @return True when a valid filename was produced.
+**/
+bool SVG_Nav_BuildDefaultCacheFilename( char *outFilename, size_t outSize );
+
+/**
+*   @brief  Return a short name for the active traversal backend.
+*   @return "voxel" or "detour-prototype".
+**/
+const char *SVG_Nav_GetPathBackendName( void );
+
+/**
+*   @brief  Runtime metrics for the optional detour-prototype backend.
+**/
+struct nav_backend_profile_t {
+	//! Number of detour-prototype queries attempted.
+	int32_t detour_queries = 0;
+	//! Number of detour-prototype queries that produced a path.
+	int32_t detour_success = 0;
+	//! Number of detour-prototype queries that failed.
+	int32_t detour_failed = 0;
+	//! Total detour-prototype query time in milliseconds.
+	uint64_t detour_total_ms = 0;
+	//! Max detour-prototype query time in milliseconds.
+	uint64_t detour_max_ms = 0;
+	//! Total waypoint count before detour post-processing/string-pull.
+	int64_t detour_points_before = 0;
+	//! Total waypoint count after detour post-processing/string-pull.
+	int64_t detour_points_after = 0;
+};
+
+/**
+*   @brief  Snapshot nav backend runtime metrics.
+**/
+void SVG_Nav_GetBackendProfile( nav_backend_profile_t *outProfile );
+
+/**
+*   @brief  Reset nav backend runtime metrics.
+**/
+void SVG_Nav_ResetBackendProfile( void );
 
 
 

--- a/src/baseq2rtxp/svgame/nav/svg_nav_agent.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_agent.cpp
@@ -1,0 +1,153 @@
+/********************************************************************
+*
+*
+*	SVGame: Navigation Agent Helpers
+*
+*
+********************************************************************/
+
+#include "svgame/svg_local.h"
+#include "svgame/nav/svg_nav_agent.h"
+#include "svgame/nav/svg_nav_request.h"
+#include "svgame/nav/svg_nav_traversal.h"
+
+static bool NavAgent_IsBBoxValid( const Vector3 &mins, const Vector3 &maxs ) {
+	return maxs.x > mins.x
+		&& maxs.y > mins.y
+		&& maxs.z > mins.z;
+}
+
+void SVG_NavAgent_GetQueryBBox( const svg_base_edict_t *ent, Vector3 *out_mins, Vector3 *out_maxs ) {
+	if ( !out_mins || !out_maxs ) {
+		return;
+	}
+
+	const nav_mesh_t *mesh = g_nav_mesh.get();
+	if ( mesh && NavAgent_IsBBoxValid( mesh->agent_mins, mesh->agent_maxs ) ) {
+		*out_mins = mesh->agent_mins;
+		*out_maxs = mesh->agent_maxs;
+		return;
+	}
+
+	const nav_agent_profile_t agentProfile = SVG_Nav_BuildAgentProfileFromCvars();
+	if ( NavAgent_IsBBoxValid( agentProfile.mins, agentProfile.maxs ) ) {
+		*out_mins = agentProfile.mins;
+		*out_maxs = agentProfile.maxs;
+		return;
+	}
+
+	if ( ent && NavAgent_IsBBoxValid( ent->mins, ent->maxs ) ) {
+		*out_mins = ent->mins;
+		*out_maxs = ent->maxs;
+		return;
+	}
+
+	*out_mins = {};
+	*out_maxs = {};
+}
+
+void SVG_NavAgent_ResetPathProcess( svg_nav_path_process_t *pathProcess ) {
+	if ( !pathProcess ) {
+		return;
+	}
+
+	if ( pathProcess->pending_request_handle > 0 ) {
+		SVG_Nav_CancelRequest( pathProcess->pending_request_handle );
+	}
+
+	SVG_Nav_FreeTraversalPath( &pathProcess->path );
+	pathProcess->path_index = 0;
+	pathProcess->path_goal = {};
+	pathProcess->path_start = {};
+	pathProcess->path_center_offset_z = 0.0f;
+	pathProcess->rebuild_in_progress = false;
+	pathProcess->pending_request_handle = 0;
+}
+
+bool SVG_NavAgent_TryQueueRebuild( svg_nav_path_process_t *pathProcess, int32_t ownerEntNum,
+	const Vector3 &start_origin, const Vector3 &goal_origin, const svg_nav_path_policy_t &policy,
+	const Vector3 &agent_mins, const Vector3 &agent_maxs, bool force, bool emitDebug ) {
+	if ( !pathProcess ) {
+		return false;
+	}
+
+	if ( !nav_nav_async_queue_mode || nav_nav_async_queue_mode->integer == 0 ) {
+		if ( emitDebug ) {
+			gi.dprintf( "[NavAgent] queue disabled; cannot enqueue ent=%d\n", ownerEntNum );
+		}
+		return false;
+	}
+
+	if ( !SVG_Nav_IsAsyncNavEnabled() ) {
+		if ( emitDebug ) {
+			gi.dprintf( "[NavAgent] async nav globally disabled ent=%d\n", ownerEntNum );
+		}
+		return false;
+	}
+
+	const bool occupancyWarrantsRebuild = pathProcess->ShouldRebuildForOccupancy( policy );
+	const bool effectiveForce = force || occupancyWarrantsRebuild;
+
+	if ( !effectiveForce && !pathProcess->CanRebuild( policy ) ) {
+		if ( emitDebug ) {
+			gi.dprintf( "[NavAgent] throttled/backoff ent=%d next_rebuild=%lld backoff_until=%lld\n",
+				ownerEntNum,
+				(long long)pathProcess->next_rebuild_time.Milliseconds(),
+				(long long)pathProcess->backoff_until.Milliseconds() );
+		}
+		return true;
+	}
+
+	const bool movementWarrantsRebuild =
+		pathProcess->ShouldRebuildForGoal2D( goal_origin, policy )
+		|| pathProcess->ShouldRebuildForGoal3D( goal_origin, policy )
+		|| pathProcess->ShouldRebuildForStart2D( start_origin, policy )
+		|| pathProcess->ShouldRebuildForStart3D( start_origin, policy );
+
+	if ( !effectiveForce && !movementWarrantsRebuild ) {
+		if ( emitDebug ) {
+			gi.dprintf( "[NavAgent] rebuild not warranted ent=%d\n", ownerEntNum );
+		}
+		return true;
+	}
+
+	if ( SVG_Nav_IsRequestPending( pathProcess ) ) {
+		if ( emitDebug ) {
+			gi.dprintf( "[NavAgent] request already pending ent=%d\n", ownerEntNum );
+		}
+		return true;
+	}
+
+	const nav_request_handle_t handle = SVG_Nav_RequestPathAsync( pathProcess, start_origin, goal_origin,
+		policy, agent_mins, agent_maxs, effectiveForce );
+	if ( handle <= 0 ) {
+		if ( emitDebug ) {
+			gi.dprintf( "[NavAgent] enqueue failed handle=%d ent=%d\n", handle, ownerEntNum );
+		}
+		return false;
+	}
+
+	pathProcess->rebuild_in_progress = true;
+	pathProcess->pending_request_handle = handle;
+	if ( occupancyWarrantsRebuild ) {
+		pathProcess->MarkOccupancyRebuildScheduled( policy );
+	}
+
+	if ( emitDebug ) {
+		gi.dprintf( "[NavAgent] queued rebuild handle=%d ent=%d force=%d occupancy=%d\n",
+			handle, ownerEntNum, effectiveForce ? 1 : 0, occupancyWarrantsRebuild ? 1 : 0 );
+
+		const nav_mesh_t *mesh = g_nav_mesh.get();
+		if ( mesh ) {
+			const Vector3 start_center = SVG_Nav_ConvertFeetToCenter( mesh, start_origin, &agent_mins, &agent_maxs );
+			const Vector3 goal_center = SVG_Nav_ConvertFeetToCenter( mesh, goal_origin, &agent_mins, &agent_maxs );
+			gi.dprintf( "[NavAgent] start=(%.1f %.1f %.1f) start_center=(%.1f %.1f %.1f) goal=(%.1f %.1f %.1f) goal_center=(%.1f %.1f %.1f)\n",
+				start_origin.x, start_origin.y, start_origin.z,
+				start_center.x, start_center.y, start_center.z,
+				goal_origin.x, goal_origin.y, goal_origin.z,
+				goal_center.x, goal_center.y, goal_center.z );
+		}
+	}
+
+	return true;
+}

--- a/src/baseq2rtxp/svgame/nav/svg_nav_agent.h
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_agent.h
@@ -1,0 +1,48 @@
+/********************************************************************
+*
+*
+*	SVGame: Navigation Agent Helpers
+*
+*
+********************************************************************/
+#pragma once
+
+#include "svgame/nav/svg_nav.h"
+#include "svgame/nav/svg_nav_path_process.h"
+
+struct svg_base_edict_t;
+
+/**
+*	@brief	Resolve a feet-origin agent bbox suitable for nav queries.
+*	@param	ent		Entity requesting a bbox (optional, may be null).
+*	@param	out_mins	[out] Feet-origin mins.
+*	@param	out_maxs	[out] Feet-origin maxs.
+*	@note	Preference order:
+*			1) active mesh generation bounds,
+*			2) current nav agent cvar profile,
+*			3) entity collision bounds,
+*			4) zero extents fallback.
+**/
+void SVG_NavAgent_GetQueryBBox( const svg_base_edict_t *ent, Vector3 *out_mins, Vector3 *out_maxs );
+
+/**
+*	@brief	Cancel pending async work and clear a path-process cache.
+**/
+void SVG_NavAgent_ResetPathProcess( svg_nav_path_process_t *pathProcess );
+
+/**
+*	@brief	Standard async rebuild orchestration shared by AI entities.
+*	@param	pathProcess		Entity-local path process state.
+*	@param	ownerEntNum		Entity number used in debug logging.
+*	@param	start_origin	Feet-origin start.
+*	@param	goal_origin	Feet-origin goal.
+*	@param	policy		Path policy used for rebuild heuristics.
+*	@param	agent_mins	Feet-origin bbox mins.
+*	@param	agent_maxs	Feet-origin bbox maxs.
+*	@param	force		Bypass movement throttle heuristics.
+*	@param	emitDebug	Emit verbose queue diagnostics.
+*	@return	True when the request is queued or intentionally deferred.
+**/
+bool SVG_NavAgent_TryQueueRebuild( svg_nav_path_process_t *pathProcess, int32_t ownerEntNum,
+	const Vector3 &start_origin, const Vector3 &goal_origin, const svg_nav_path_policy_t &policy,
+	const Vector3 &agent_mins, const Vector3 &agent_maxs, bool force = false, bool emitDebug = false );

--- a/src/baseq2rtxp/svgame/nav/svg_nav_debug.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_debug.cpp
@@ -15,6 +15,8 @@
 #include "svgame/nav/svg_nav.h"
 #include "svgame/nav/svg_nav_debug.h"
 
+#include <algorithm>
+
 
 
 //! Global debug draw state.
@@ -452,17 +454,6 @@ void SVG_Nav_DebugDraw( void ) {
 		return;
 	}
 
-	/**
-	*	Map: owner_entnum -> runtime entry.
-	*	We use the cached lookup map instead of a per-frame linear scan.
-	**/
-	auto find_runtime = [mesh]( const svg_base_edict_t *owner ) -> const nav_inline_model_runtime_t * {
-		if ( !owner ) {
-			return nullptr;
-		}
-		return SVG_Nav_GetInlineModelRuntimeForOwnerEntNum( mesh, owner->s.number );
-	};
-
 	for ( int32_t i = 0; i < mesh->num_inline_models; i++ ) {
 		const nav_inline_model_data_t *model = &mesh->inline_model_data[ i ];
 		if ( !model || model->num_tiles <= 0 || !model->tiles ) {
@@ -497,9 +488,7 @@ void SVG_Nav_DebugDraw( void ) {
 			continue;
 		}
 
-		// Debug draw for inline models currently ignores rotation (angles) and uses translation only.
-		// This is still useful for doors/platforms that primarily translate.
-		const Vector3 origin = rt->origin;
+		const nav_rigid_xform_t xform = SVG_Nav_BuildRigidXform( rt->origin, rt->angles );
 
 		for ( int32_t t = 0; t < model->num_tiles; t++ ) {
 			const nav_tile_t *tile = &model->tiles[ t ];
@@ -513,14 +502,33 @@ void SVG_Nav_DebugDraw( void ) {
 				continue;
 			}
 
-			// Tile bounds (translated).
+			// Tile bounds (transformed to world and conservatively drawn as world AABB).
 			if ( NavDebug_Enabled() && nav_debug_draw_tile_bounds && nav_debug_draw_tile_bounds->integer != 0 ) {
 				if ( NavDebug_CanEmitSegments( 12 ) ) {
 					const Vector3 minsLocal = { tile->tile_x * tileWorldSize, tile->tile_y * tileWorldSize, -4096.0 /* <Q2RTXP>: TODO: world_bounds.mins.z */ };
 					const Vector3 maxsLocal = { minsLocal[ 0 ] + tileWorldSize, minsLocal[ 1 ] + tileWorldSize, 4096.0 /* <Q2RTXP>: TODO: world_bounds.maxs.z */ };
 
-					const Vector3 minsWorld = QM_Vector3Add( minsLocal, origin );
-					const Vector3 maxsWorld = QM_Vector3Add( maxsLocal, origin );
+					Vector3 minsWorld = { 1e30, 1e30, 1e30 };
+					Vector3 maxsWorld = { -1e30, -1e30, -1e30 };
+					for ( int32_t ix = 0; ix < 2; ix++ ) {
+						for ( int32_t iy = 0; iy < 2; iy++ ) {
+							for ( int32_t iz = 0; iz < 2; iz++ ) {
+								const Vector3 cornerLocal = {
+									ix ? maxsLocal[ 0 ] : minsLocal[ 0 ],
+									iy ? maxsLocal[ 1 ] : minsLocal[ 1 ],
+									iz ? maxsLocal[ 2 ] : minsLocal[ 2 ]
+								};
+								const Vector3 cornerWorld = SVG_Nav_WorldFromLocal( xform, cornerLocal );
+
+								minsWorld[ 0 ] = std::min( minsWorld[ 0 ], cornerWorld[ 0 ] );
+								minsWorld[ 1 ] = std::min( minsWorld[ 1 ], cornerWorld[ 1 ] );
+								minsWorld[ 2 ] = std::min( minsWorld[ 2 ], cornerWorld[ 2 ] );
+								maxsWorld[ 0 ] = std::max( maxsWorld[ 0 ], cornerWorld[ 0 ] );
+								maxsWorld[ 1 ] = std::max( maxsWorld[ 1 ], cornerWorld[ 1 ] );
+								maxsWorld[ 2 ] = std::max( maxsWorld[ 2 ], cornerWorld[ 2 ] );
+							}
+						}
+					}
 
 					const Vector3 center = { ( double )( minsWorld[ 0 ] + maxsWorld[ 0 ] ) * 0.5, ( double )( minsWorld[ 1 ] + maxsWorld[ 1 ] ) * 0.5, 0.0 };
 					if ( NavDebug_PassesDistanceFilter( center ) ) {
@@ -532,7 +540,7 @@ void SVG_Nav_DebugDraw( void ) {
 				}
 			}
 
-			// Samples (translated).
+			// Samples (transformed).
 			if ( nav_debug_draw_samples && nav_debug_draw_samples->integer != 0 ) {
 				const double tileOriginXLocal = tile->tile_x * tileWorldSize;
 				const double tileOriginYLocal = tile->tile_y * tileWorldSize;
@@ -553,7 +561,7 @@ void SVG_Nav_DebugDraw( void ) {
 						( double )layer->z_quantized * ( double )mesh->z_quant
 					};
 
-					Vector3 pWorld = QM_Vector3Add( pLocal, origin );
+					Vector3 pWorld = SVG_Nav_WorldFromLocal( xform, pLocal );
 					NavDebug_DrawSampleTick( pWorld, 12.0 );
 
 					if ( !NavDebug_CanEmitSegments( 1 ) ) {

--- a/src/baseq2rtxp/svgame/nav/svg_nav_generate.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_generate.cpp
@@ -55,7 +55,8 @@ static void Nav_FreeTileCells( nav_tile_t *tile, int32_t cells_per_tile );
 static void FindWalkableLayers( const Vector3 &xy_pos, const Vector3 &mins, const Vector3 &maxs,
                                 double z_min, double z_max, double max_step, double max_slope_deg, double z_quant,
                                 nav_layer_t **out_layers, int32_t *out_num_layers,
-                                const edict_ptr_t *clip_entity );
+                                const edict_ptr_t *clip_entity, const nav_rigid_xform_t *clip_xform,
+                                bool sample_in_local_space );
 static bool Nav_BuildTile( nav_mesh_t *mesh, nav_tile_t *tile, const Vector3 &leaf_mins, const Vector3 &leaf_maxs,
                            double z_min, double z_max );
 static bool Nav_BuildInlineTile( nav_mesh_t *mesh, nav_tile_t *tile, const Vector3 &model_mins, const Vector3 &model_maxs,
@@ -145,12 +146,15 @@ static int32_t s_slope_reject_count = 0;
 *	@param	out_layers	[out] Heap-allocated layer buffer (TAG_SVGAME_LEVEL) or nullptr.
 *	@param	out_num_layers	[out] Number of layers returned in `out_layers`.
 *	@param	clip_entity	Optional inline-model clip entity for model-local sampling (nullptr for world sampling).
+*	@param	clip_xform	Rigid transform for inline-model local/world conversion.
+*	@param	sample_in_local_space	If true and `clip_entity` is set, traces are generated from local XY/Z and transformed to world.
 *	@note	Not thread-safe due to internal static scratch storage.
 */
 static void FindWalkableLayers( const Vector3 &xy_pos, const Vector3 &mins, const Vector3 &maxs,
                                 double z_min, double z_max, double max_step, double max_slope_deg, double z_quant,
                                 nav_layer_t **out_layers, int32_t *out_num_layers,
-                                const edict_ptr_t *clip_entity ) {
+                                const edict_ptr_t *clip_entity, const nav_rigid_xform_t *clip_xform,
+                                bool sample_in_local_space ) {
     const int32_t MAX_LAYERS = 16;
     static nav_layer_t temp_layers[ MAX_LAYERS ] = {};
     int32_t num_layers = 0;
@@ -263,50 +267,48 @@ static void FindWalkableLayers( const Vector3 &xy_pos, const Vector3 &mins, cons
     *        Repeatedly trace downward to discover multiple floors at the same XY.
     **/
     while ( current_z > z_min && num_layers < MAX_LAYERS ) {
-        Vector3 start = xy_pos; start[2] = current_z;
-        Vector3 end = xy_pos; end[2] = current_z - step_down;
+        Vector3 sample_start = xy_pos;
+        sample_start[ 2 ] = current_z;
+        Vector3 sample_end = xy_pos;
+        sample_end[ 2 ] = current_z - step_down;
+
+        const bool use_local_inline = ( clip_entity && clip_xform && sample_in_local_space );
+        Vector3 trace_start = sample_start;
+        Vector3 trace_end = sample_end;
+        if ( use_local_inline ) {
+            trace_start = SVG_Nav_WorldFromLocal( *clip_xform, sample_start );
+            trace_end = SVG_Nav_WorldFromLocal( *clip_xform, sample_end );
+        }
 
         cm_trace_t trace;
         if ( clip_entity ) {
-            trace = gi.clip( clip_entity, &start, &mins, &maxs, &end, CM_CONTENTMASK_SOLID );
+            trace = gi.clip( clip_entity, &trace_start, &mins, &maxs, &trace_end, CM_CONTENTMASK_SOLID );
         } else {
-            trace = gi.trace( &start, &mins, &maxs, &end, nullptr, CM_CONTENTMASK_SOLID );
+            trace = gi.trace( &trace_start, &mins, &maxs, &trace_end, nullptr, CM_CONTENTMASK_SOLID );
         }
 
         s_trace_attempt_count++;
 
+        double trace_end_sample_z = trace.endpos[ 2 ];
+        Vector3 slope_normal = trace.plane.normal;
+        if ( use_local_inline ) {
+            const Vector3 local_end = SVG_Nav_LocalFromWorld( *clip_xform, trace.endpos );
+            trace_end_sample_z = local_end[ 2 ];
+            slope_normal = SVG_Nav_LocalDirectionFromWorld( *clip_xform, trace.plane.normal );
+        }
+
         // Record valid upward-facing hit surfaces.
-			if ( trace.fraction < 1.0f && trace.plane.normal[2] > 0.0f ) {
+			if ( trace.fraction < 1.0f && slope_normal[ 2 ] > 0.0f ) {
 				s_trace_hit_count++;
 				// Enforce slope threshold in terms of normal.z.
-				if ( ( trace.plane.normal[2] >= cosf( max_slope_deg * DEG_TO_RAD ) ) ) {
+				if ( ( slope_normal[ 2 ] >= cosf( max_slope_deg * DEG_TO_RAD ) ) ) {
 				/**
 				*    Quantize the sampled Z using rounding so nearby layers don't collapse
 				*    downwards when the trace endpos is close to the next quant step.
 				*    If we are sampling an inline model, transform the world-space hit
 				*    back into model-local space before storing.
 				**/
-				double worldZ = trace.endpos[ 2 ];
-				double localZ = worldZ;
-				if ( clip_entity ) {
-					// Transform world-space hit to model-local Z.
-					Vector3 p_l = QM_Vector3Subtract( trace.endpos, clip_entity->currentOrigin );
-					if ( clip_entity->currentAngles.x != 0 || clip_entity->currentAngles.y != 0 || clip_entity->currentAngles.z != 0 ) {
-						Vector3 f, r, u;
-						QM_AngleVectors( clip_entity->currentAngles, &f, &r, &u );
-						// World-to-local rotation using projection (dots with basis).
-						localZ = p_l.x * f.x + p_l.y * f.y + p_l.z * f.z; // This is not quite correct for all rotations but it matches yaw.
-						// Actually, better to just use dot products for full transform:
-						localZ = p_l.x * f.z + p_l.y * r.z + p_l.z * u.z; // No, it's simpler:
-						// Let's just do it properly.
-						localZ = QM_Vector3DotProduct( p_l, u ); // Correct for local Z? Not necessarily.
-						// In Q2: f = local +X, r = local -Y, u = local +Z. 
-						// So localZ is dot( p_l, u ).
-						localZ = (double)QM_Vector3DotProduct( p_l, u );
-					} else {
-						localZ = (double)p_l.z;
-					}
-				}
+				const double localZ = trace_end_sample_z;
 
 				const double quantizedZ = std::lround( localZ / z_quant );
 				constexpr double quantMin = ( double )std::numeric_limits<int32_t>::min();
@@ -319,7 +321,7 @@ static void FindWalkableLayers( const Vector3 &xy_pos, const Vector3 &mins, cons
                     *    Trace upward from the detected floor to measure the next obstruction
                     *    and derive vertical clearance in quantized units.
                     **/
-                    const double clearance_probe_start_z = trace.endpos[2] + 1.0;
+                    const double clearance_probe_start_z = trace_end_sample_z + 1.0;
                     double ceiling_z = z_max;
                     if ( clearance_probe_start_z < z_max ) {
                         Vector3 ceiling_start = xy_pos;
@@ -327,19 +329,31 @@ static void FindWalkableLayers( const Vector3 &xy_pos, const Vector3 &mins, cons
                         Vector3 ceiling_end = xy_pos;
                         ceiling_end[2] = z_max;
 
+						Vector3 ceiling_trace_start = ceiling_start;
+						Vector3 ceiling_trace_end = ceiling_end;
+						if ( use_local_inline ) {
+							ceiling_trace_start = SVG_Nav_WorldFromLocal( *clip_xform, ceiling_start );
+							ceiling_trace_end = SVG_Nav_WorldFromLocal( *clip_xform, ceiling_end );
+						}
+
                         cm_trace_t ceiling_trace;
                         if ( clip_entity ) {
-                            ceiling_trace = gi.clip( clip_entity, &ceiling_start, &mins, &maxs, &ceiling_end, CM_CONTENTMASK_SOLID );
+                            ceiling_trace = gi.clip( clip_entity, &ceiling_trace_start, &mins, &maxs, &ceiling_trace_end, CM_CONTENTMASK_SOLID );
                         } else {
-                            ceiling_trace = gi.trace( &ceiling_start, &mins, &maxs, &ceiling_end, nullptr, CM_CONTENTMASK_SOLID );
+                            ceiling_trace = gi.trace( &ceiling_trace_start, &mins, &maxs, &ceiling_trace_end, nullptr, CM_CONTENTMASK_SOLID );
                         }
 
                         if ( ceiling_trace.fraction < 1.0f ) {
-                            ceiling_z = ceiling_trace.endpos[2];
+							if ( use_local_inline ) {
+								const Vector3 local_ceiling = SVG_Nav_LocalFromWorld( *clip_xform, ceiling_trace.endpos );
+								ceiling_z = local_ceiling[ 2 ];
+							} else {
+								ceiling_z = ceiling_trace.endpos[ 2 ];
+							}
                         }
                     }
 
-                    double clearance_world = ceiling_z - trace.endpos[2];
+                    double clearance_world = ceiling_z - trace_end_sample_z;
                     if ( clearance_world < 0.0 ) {
                         clearance_world = 0.0;
                     }
@@ -358,14 +372,14 @@ static void FindWalkableLayers( const Vector3 &xy_pos, const Vector3 &mins, cons
 		temp_layers[num_layers].clearance = clearance_store;
 
                     num_layers++;
-                    current_z = trace.endpos[2] - 1.0f;
+                    current_z = trace_end_sample_z - 1.0f;
                 } else {
                     s_slope_reject_count++;
                     if ( SVG_Nav_ProfileEnabled( 3 ) ) {
                         SVG_Nav_Log( "[NavProfile] FindWalkableLayers: trace hit but slope rejected normal.z=%.3f max_slope_deg=%.1f at z=%.2f\n",
-                            trace.plane.normal[2], max_slope_deg, trace.endpos[2] );
+                            slope_normal[ 2 ], max_slope_deg, trace_end_sample_z );
                     }
-                    current_z = trace.endpos[2] - 1.0f;
+                    current_z = trace_end_sample_z - 1.0f;
                 }
             } else {
                 if ( SVG_Nav_ProfileEnabled( 3 ) ) {
@@ -434,7 +448,7 @@ static bool Nav_BuildTile( nav_mesh_t *mesh, nav_tile_t *tile, const Vector3 &le
 
             FindWalkableLayers( xy_pos, mesh->agent_mins, mesh->agent_maxs,
                                 z_min, z_max, mesh->max_step, mesh->max_slope_deg, mesh->z_quant,
-                                &layers, &num_layers, nullptr );
+                                &layers, &num_layers, nullptr, nullptr, false );
 
             if ( num_layers > 0 ) {
                 const int32_t cell_index = cell_y * mesh->tile_size + cell_x;
@@ -488,6 +502,9 @@ static bool Nav_BuildInlineTile( nav_mesh_t *mesh, nav_tile_t *tile, const Vecto
 
     const double tile_origin_x = model_mins[ 0 ] + ( tile->tile_x * tile_world_size );
     const double tile_origin_y = model_mins[ 1 ] + ( tile->tile_y * tile_world_size );
+	const nav_rigid_xform_t clip_xform = clip_entity
+		? SVG_Nav_BuildRigidXform( clip_entity->currentOrigin, clip_entity->currentAngles )
+		: nav_rigid_xform_t{};
 
     for ( int32_t cell_y = 0; cell_y < mesh->tile_size; cell_y++ ) {
         for ( int32_t cell_x = 0; cell_x < mesh->tile_size; cell_x++ ) {
@@ -503,46 +520,9 @@ static bool Nav_BuildInlineTile( nav_mesh_t *mesh, nav_tile_t *tile, const Vecto
             nav_layer_t *layers = nullptr;
             int32_t num_layers = 0;
 
-            // Inline-model sampling: the collision clip implementation expects
-            // world-space positions when tracing against an entity clip model.
-            // Convert the model-local XY/Z into world-space using the entity's
-            // currentOrigin and currentAngles before performing traces.
-            Vector3 world_xy = xy_pos;
-            double world_z_min = z_min;
-            double world_z_max = z_max;
-
-            if ( clip_entity ) {
-                // Local to World transform:
-                Vector3 local_center = xy_pos;
-                local_center.z = (float)( ( z_min + z_max ) * 0.5 );
-
-                if ( clip_entity->currentAngles.x != 0 || clip_entity->currentAngles.y != 0 || clip_entity->currentAngles.z != 0 ) {
-                    Vector3 f, r, u;
-                    QM_AngleVectors( clip_entity->currentAngles, &f, &r, &u );
-                    // Transform local to world: origin + (x*f + y*-r + z*u)
-                    // (Standard Q2/QMRay calculation).
-                    Vector3 rotated = {
-                        local_center.x * f.x + local_center.y * -r.x + local_center.z * u.x,
-                        local_center.x * f.y + local_center.y * -r.y + local_center.z * u.y,
-                        local_center.x * f.z + local_center.y * -r.z + local_center.z * u.z
-                    };
-                    world_xy = QM_Vector3Add( rotated, clip_entity->currentOrigin );
-
-                    // For Z range, we take the average vertical displacement or just add origin.z
-                    // since rotation around non-Z axes is rare for inline models in Q2.
-                    // For a simple column precheck, we just shift the range.
-                    world_z_min = z_min + clip_entity->currentOrigin[ 2 ]; // This is a simplification.
-                    world_z_max = z_max + clip_entity->currentOrigin[ 2 ];
-                } else {
-                    world_xy = QM_Vector3Add( xy_pos, clip_entity->currentOrigin );
-                    world_z_min = z_min + clip_entity->currentOrigin[ 2 ];
-                    world_z_max = z_max + clip_entity->currentOrigin[ 2 ];
-                }
-            }
-
-            FindWalkableLayers( world_xy, mesh->agent_mins, mesh->agent_maxs,
-                                world_z_min, world_z_max, mesh->max_step, mesh->max_slope_deg, mesh->z_quant,
-                                &layers, &num_layers, clip_entity );
+            FindWalkableLayers( xy_pos, mesh->agent_mins, mesh->agent_maxs,
+                                z_min, z_max, mesh->max_step, mesh->max_slope_deg, mesh->z_quant,
+                                &layers, &num_layers, clip_entity, clip_entity ? &clip_xform : nullptr, true );
 
             if ( num_layers > 0 ) {
                 const int32_t cell_index = cell_y * mesh->tile_size + cell_x;
@@ -647,6 +627,7 @@ void GenerateWorldMesh( nav_mesh_t *mesh ) {
     if ( !mesh ) {
         return;
     }
+    mesh->profile_world_gen_ms = 0.0;
 
     const cm_t *world_model = gi.GetCollisionModel();
     if ( !world_model || !world_model->cache ) {
@@ -660,7 +641,7 @@ void GenerateWorldMesh( nav_mesh_t *mesh ) {
     *    Log start of world mesh generation and stamp start time for profiling.
     **/
     SVG_Nav_Log( "Generating world navmesh (tile-first approach)...\n" );
-    const QMTime t0 = level.time;
+    const uint64_t worldStartMs = gi.GetRealSystemTime();
 
     mesh->num_leafs = num_leafs;
     mesh->leaf_data = (nav_leaf_data_t *)gi.TagMallocz( sizeof( nav_leaf_data_t ) * num_leafs, TAG_SVGAME_LEVEL );
@@ -792,8 +773,8 @@ void GenerateWorldMesh( nav_mesh_t *mesh ) {
     /**
     *    Phase complete: record elapsed time and log summary statistics.
     **/
-	QMTime t1 = QMTime::FromMilliseconds( gi.GetRealSystemTime() );
-    const double elapsedMs = ( double )( t1 - t0 ).Seconds();
+    const double elapsedMs = ( double )( gi.GetRealSystemTime() - worldStartMs );
+    mesh->profile_world_gen_ms = elapsedMs;
     SVG_Nav_Log( "World mesh generation complete (tile-first) - %.2f ms\n", elapsedMs );
     SVG_Nav_Log( "  Tiles attempted: %d\n", total_tile_attempts );
     SVG_Nav_Log( "  Tiles skipped (empty): %d (%.1f%%)\n",
@@ -814,6 +795,11 @@ void GenerateWorldMesh( nav_mesh_t *mesh ) {
 *	@param	mesh	Navigation mesh structure to populate.
 */
 void GenerateInlineModelMesh( nav_mesh_t *mesh ) {
+    if ( !mesh ) {
+        return;
+    }
+    mesh->profile_inline_gen_ms = 0.0;
+
     const cm_t *world_model = gi.GetCollisionModel();
     if ( !world_model || !world_model->cache ) {
         SVG_Nav_Log( "Failed to get world BSP data\n" );
@@ -833,7 +819,7 @@ void GenerateInlineModelMesh( nav_mesh_t *mesh ) {
 
     // Log start of inline model generation and measure phase time.
     SVG_Nav_Log( "Generating inline model navmesh for %d inline models...\n", ( int32_t )model_to_ent.size() );
-    const QMTime t0 = level.time;
+    const uint64_t inlineStartMs = gi.GetRealSystemTime();
 
     mesh->num_inline_models = ( int32_t )model_to_ent.size();
     mesh->inline_model_data = ( nav_inline_model_data_t * )gi.TagMallocz(
@@ -917,8 +903,8 @@ void GenerateInlineModelMesh( nav_mesh_t *mesh ) {
         out_index++;
     }
 
-    const QMTime t1 = level.time;
-    const double elapsedMs = ( double )( t1 - t0 ).Milliseconds();
+    const double elapsedMs = ( double )( gi.GetRealSystemTime() - inlineStartMs );
+    mesh->profile_inline_gen_ms = elapsedMs;
     SVG_Nav_Log( "Inline models' navmesh generation complete - %.2f ms\n", elapsedMs );
 
     // Diagnostic: print a histogram of layer counts across inline model tiles (if any) to detect abnormal distributions.
@@ -1024,12 +1010,18 @@ void SVG_Nav_GenerateVoxelMesh( void ) {
 
 	// Generate world and inline meshes with timing.
 	const QMTime genStart = QMTime::FromMilliseconds( gi.GetRealSystemTime() );
+	g_nav_mesh->profile_world_gen_ms = 0.0;
+	g_nav_mesh->profile_inline_gen_ms = 0.0;
+	g_nav_mesh->profile_total_gen_ms = 0.0;
+	g_nav_mesh->profile_generated_at_ms = 0;
 	GenerateWorldMesh( g_nav_mesh.get() );
     GenerateInlineModelMesh( g_nav_mesh.get() );
     // Emit a short inline-model generation summary to help debug missing inline tiles.
     Nav_LogInlineModelSummary( g_nav_mesh.get() );
 	const QMTime genEnd = QMTime::FromMilliseconds( gi.GetRealSystemTime() );
 	const double genElapsedMs = ( double )( genEnd - genStart ).Milliseconds();
+	g_nav_mesh->profile_total_gen_ms = genElapsedMs;
+	g_nav_mesh->profile_generated_at_ms = gi.GetRealSystemTime();
 	SVG_Nav_Log( "Overall generation time: %.2f ms\n", genElapsedMs );
 
 	// Calculate stats

--- a/src/baseq2rtxp/svgame/nav/svg_nav_load.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_load.cpp
@@ -21,12 +21,96 @@
 	#define gzFile                      FILE *
 #endif
 
+#include <cmath>
 #include <cstdint>
 #include <unordered_map>
 #include <vector>
 
 static constexpr uint32_t NAV_MESH_SAVE_MAGIC = 0x56414E53; // "VANS"
-static constexpr uint32_t NAV_MESH_SAVE_VERSION = 1;
+static constexpr uint32_t NAV_MESH_SAVE_VERSION_V1 = 1;
+static constexpr uint32_t NAV_MESH_SAVE_VERSION_V2 = 2;
+static constexpr uint32_t NAV_MESH_SAVE_ENDIAN_MARKER = 0x12345678;
+
+static constexpr uint32_t Nav_FourCC( const char a, const char b, const char c, const char d ) {
+	return (uint32_t)(uint8_t)a |
+		( (uint32_t)(uint8_t)b << 8 ) |
+		( (uint32_t)(uint8_t)c << 16 ) |
+		( (uint32_t)(uint8_t)d << 24 );
+}
+
+static constexpr uint32_t NAV_CHUNK_PARAM = Nav_FourCC( 'P', 'A', 'R', 'M' );
+static constexpr uint32_t NAV_CHUNK_WORLD_TILES = Nav_FourCC( 'W', 'T', 'I', 'L' );
+static constexpr uint32_t NAV_CHUNK_LEAF_MAP = Nav_FourCC( 'L', 'E', 'A', 'F' );
+static constexpr uint32_t NAV_CHUNK_INLINE_MODELS = Nav_FourCC( 'I', 'M', 'O', 'D' );
+
+static uint32_t Nav_Hash32( const void *data, const size_t size ) {
+	const uint8_t *bytes = (const uint8_t *)data;
+	uint32_t hash = 2166136261u;
+	for ( size_t i = 0; i < size; i++ ) {
+		hash ^= bytes[ i ];
+		hash *= 16777619u;
+	}
+	return hash;
+}
+
+struct nav_cache_param_chunk_t {
+	double cell_size_xy = 0.0;
+	double z_quant = 0.0;
+	int32_t tile_size = 0;
+	double max_step = 0.0;
+	double max_slope_deg = 0.0;
+	Vector3 agent_mins = {};
+	Vector3 agent_maxs = {};
+	int32_t num_leafs = 0;
+	int32_t num_inline_models = 0;
+	int32_t num_world_tiles = 0;
+};
+
+static uint32_t Nav_CalcMapHash( void ) {
+	if ( !level.mapname[ 0 ] ) {
+		return 0;
+	}
+	return Nav_Hash32( level.mapname, strlen( level.mapname ) );
+}
+
+static uint32_t Nav_CalcParamsHash( const nav_cache_param_chunk_t &params ) {
+	const nav_cache_param_chunk_t hashData = params;
+	return Nav_Hash32( &hashData, sizeof( hashData ) );
+}
+
+static inline bool Nav_NearlyEqual( const double a, const double b, const double eps = 0.0001 ) {
+	return std::fabs( a - b ) <= eps;
+}
+
+static bool Nav_ParamChunkMatchesActiveCvars( const nav_cache_param_chunk_t &params ) {
+	const double runtimeCellSize = nav_cell_size_xy ? nav_cell_size_xy->value : params.cell_size_xy;
+	const double runtimeZQuant = nav_z_quant ? nav_z_quant->value : params.z_quant;
+	const int32_t runtimeTileSize = nav_tile_size ? nav_tile_size->integer : params.tile_size;
+	const double runtimeMaxStep = nav_max_step ? nav_max_step->value : params.max_step;
+	const double runtimeMaxSlope = nav_max_slope_deg ? nav_max_slope_deg->value : params.max_slope_deg;
+	const Vector3 runtimeMins = {
+		nav_agent_mins_x ? nav_agent_mins_x->value : (float)params.agent_mins.x,
+		nav_agent_mins_y ? nav_agent_mins_y->value : (float)params.agent_mins.y,
+		nav_agent_mins_z ? nav_agent_mins_z->value : (float)params.agent_mins.z
+	};
+	const Vector3 runtimeMaxs = {
+		nav_agent_maxs_x ? nav_agent_maxs_x->value : (float)params.agent_maxs.x,
+		nav_agent_maxs_y ? nav_agent_maxs_y->value : (float)params.agent_maxs.y,
+		nav_agent_maxs_z ? nav_agent_maxs_z->value : (float)params.agent_maxs.z
+	};
+
+	return Nav_NearlyEqual( params.cell_size_xy, runtimeCellSize )
+		&& Nav_NearlyEqual( params.z_quant, runtimeZQuant )
+		&& params.tile_size == runtimeTileSize
+		&& Nav_NearlyEqual( params.max_step, runtimeMaxStep )
+		&& Nav_NearlyEqual( params.max_slope_deg, runtimeMaxSlope )
+		&& Nav_NearlyEqual( params.agent_mins.x, runtimeMins.x )
+		&& Nav_NearlyEqual( params.agent_mins.y, runtimeMins.y )
+		&& Nav_NearlyEqual( params.agent_mins.z, runtimeMins.z )
+		&& Nav_NearlyEqual( params.agent_maxs.x, runtimeMaxs.x )
+		&& Nav_NearlyEqual( params.agent_maxs.y, runtimeMaxs.y )
+		&& Nav_NearlyEqual( params.agent_maxs.z, runtimeMaxs.z );
+}
 
 /**
 *	@brief	Read raw bytes from a (possibly gzipped) file.
@@ -71,6 +155,418 @@ static inline void Nav_SetPresenceBit_Load( nav_tile_t *tile, const int32_t cell
 	const int32_t wordIndex = cellIndex >> 5;
 	const int32_t bitIndex = cellIndex & 31;
 	tile->presence_bits[ wordIndex ] |= ( 1u << bitIndex );
+}
+
+struct nav_chunk_reader_t {
+	const uint8_t *data = nullptr;
+	size_t size = 0;
+	size_t offset = 0;
+};
+
+static bool Nav_ChunkRead( nav_chunk_reader_t *reader, void *out, const size_t bytes ) {
+	if ( !reader || !out ) {
+		return false;
+	}
+	if ( bytes == 0 ) {
+		return true;
+	}
+	if ( ( reader->offset + bytes ) > reader->size ) {
+		return false;
+	}
+
+	memcpy( out, reader->data + reader->offset, bytes );
+	reader->offset += bytes;
+	return true;
+}
+
+template<typename T>
+static bool Nav_ChunkReadValue( nav_chunk_reader_t *reader, T &out ) {
+	return Nav_ChunkRead( reader, &out, sizeof( T ) );
+}
+
+static bool Nav_ReadChunk( gzFile f, uint32_t *outChunkId, std::vector<uint8_t> *outPayload ) {
+	if ( !outChunkId || !outPayload ) {
+		return false;
+	}
+
+	uint32_t chunkId = 0;
+	uint32_t chunkSize = 0;
+	uint32_t chunkCrc = 0;
+	if ( !Nav_ReadValue( f, chunkId ) ||
+		!Nav_ReadValue( f, chunkSize ) ||
+		!Nav_ReadValue( f, chunkCrc ) ) {
+		return false;
+	}
+
+	const uint32_t maxChunkBytes = 256u * 1024u * 1024u;
+	if ( chunkSize > maxChunkBytes ) {
+		return false;
+	}
+
+	outPayload->resize( chunkSize );
+	if ( chunkSize > 0 && !Nav_Read( f, outPayload->data(), chunkSize ) ) {
+		return false;
+	}
+
+	const uint32_t calcCrc = chunkSize > 0
+		? Nav_Hash32( outPayload->data(), outPayload->size() )
+		: 0;
+	if ( calcCrc != chunkCrc ) {
+		return false;
+	}
+
+	*outChunkId = chunkId;
+	return true;
+}
+
+static bool Nav_ChunkReadTilePayload( nav_chunk_reader_t *reader, const nav_mesh_t *mesh, nav_tile_t *tile ) {
+	if ( !reader || !mesh || !tile ) {
+		return false;
+	}
+
+	const int32_t cellsPerTile = mesh->tile_size * mesh->tile_size;
+	if ( cellsPerTile <= 0 ) {
+		return false;
+	}
+
+	if ( !Nav_ChunkReadValue( reader, tile->tile_x ) ||
+		!Nav_ChunkReadValue( reader, tile->tile_y ) ) {
+		return false;
+	}
+
+	Nav_InitEmptyTileStorage( mesh, tile );
+
+	int32_t populated = 0;
+	if ( !Nav_ChunkReadValue( reader, populated ) ) {
+		return false;
+	}
+	if ( populated < 0 || populated > cellsPerTile ) {
+		return false;
+	}
+
+	for ( int32_t p = 0; p < populated; p++ ) {
+		int32_t cellIndex = 0;
+		int32_t numLayers = 0;
+		if ( !Nav_ChunkReadValue( reader, cellIndex ) ||
+			!Nav_ChunkReadValue( reader, numLayers ) ) {
+			return false;
+		}
+
+		if ( cellIndex < 0 || cellIndex >= cellsPerTile || numLayers <= 0 || numLayers > 64 ) {
+			return false;
+		}
+
+		nav_xy_cell_t &cell = tile->cells[ cellIndex ];
+		cell.num_layers = numLayers;
+		cell.layers = (nav_layer_t *)gi.TagMallocz( sizeof( nav_layer_t ) * (size_t)numLayers, TAG_SVGAME_LEVEL );
+		if ( !Nav_ChunkRead( reader, cell.layers, sizeof( nav_layer_t ) * (size_t)numLayers ) ) {
+			return false;
+		}
+
+		Nav_SetPresenceBit_Load( tile, cellIndex );
+	}
+
+	return true;
+}
+
+static bool Nav_RebuildInlineRuntimeAfterLoad( nav_mesh_t *mesh ) {
+	if ( !mesh ) {
+		return false;
+	}
+
+	mesh->num_inline_model_runtime = 0;
+	mesh->inline_model_runtime = nullptr;
+
+	if ( mesh->num_inline_models <= 0 ) {
+		return true;
+	}
+
+	std::unordered_map<int32_t, svg_base_edict_t *> model_to_ent;
+	model_to_ent.reserve( (size_t)mesh->num_inline_models );
+	for ( int32_t i = 0; i < globals.edictPool->num_edicts; i++ ) {
+		svg_base_edict_t *ent = g_edict_pool.EdictForNumber( i );
+		if ( !ent || !SVG_Entity_IsActive( ent ) ) {
+			continue;
+		}
+
+		const char *modelStr = ent->model;
+		if ( !modelStr || modelStr[ 0 ] != '*' ) {
+			continue;
+		}
+
+		const int32_t modelIndex = atoi( modelStr + 1 );
+		if ( modelIndex <= 0 ) {
+			continue;
+		}
+
+		if ( model_to_ent.find( modelIndex ) == model_to_ent.end() ) {
+			model_to_ent.emplace( modelIndex, ent );
+		}
+	}
+
+	mesh->num_inline_model_runtime = (int32_t)model_to_ent.size();
+	if ( mesh->num_inline_model_runtime > 0 ) {
+		mesh->inline_model_runtime = (nav_inline_model_runtime_t *)gi.TagMallocz(
+			sizeof( nav_inline_model_runtime_t ) * (size_t)mesh->num_inline_model_runtime, TAG_SVGAME_LEVEL );
+		int32_t out_index = 0;
+		for ( const auto &it : model_to_ent ) {
+			const int32_t model_index = it.first;
+			svg_base_edict_t *ent = it.second;
+
+			nav_inline_model_runtime_t &rt = mesh->inline_model_runtime[ out_index ];
+			rt.model_index = model_index;
+			rt.owner_ent = ent;
+			rt.owner_entnum = ent ? ent->s.number : 0;
+			rt.origin = ent ? ent->currentOrigin : Vector3{};
+			rt.angles = ent ? ent->currentAngles : Vector3{};
+			rt.dirty = false;
+			out_index++;
+		}
+	}
+
+	SVG_Nav_RefreshInlineModelRuntime();
+	return true;
+}
+
+static bool Nav_LoadVoxelMeshV2Payload( gzFile f ) {
+	if ( !f ) {
+		return false;
+	}
+
+	uint32_t endianMarker = 0;
+	uint32_t mapHash = 0;
+	uint32_t paramsHash = 0;
+	uint32_t chunkCount = 0;
+	if ( !Nav_ReadValue( f, endianMarker ) ||
+		!Nav_ReadValue( f, mapHash ) ||
+		!Nav_ReadValue( f, paramsHash ) ||
+		!Nav_ReadValue( f, chunkCount ) ) {
+		return false;
+	}
+
+	if ( endianMarker != NAV_MESH_SAVE_ENDIAN_MARKER ) {
+		return false;
+	}
+
+	std::unordered_map<uint32_t, std::vector<uint8_t>> chunks = {};
+	chunks.reserve( chunkCount );
+	for ( uint32_t i = 0; i < chunkCount; i++ ) {
+		uint32_t chunkId = 0;
+		std::vector<uint8_t> payload = {};
+		if ( !Nav_ReadChunk( f, &chunkId, &payload ) ) {
+			return false;
+		}
+		chunks[ chunkId ] = std::move( payload );
+	}
+
+	const auto paramIt = chunks.find( NAV_CHUNK_PARAM );
+	const auto worldTilesIt = chunks.find( NAV_CHUNK_WORLD_TILES );
+	const auto leafMapIt = chunks.find( NAV_CHUNK_LEAF_MAP );
+	const auto inlineIt = chunks.find( NAV_CHUNK_INLINE_MODELS );
+	if ( paramIt == chunks.end() || worldTilesIt == chunks.end() || leafMapIt == chunks.end() || inlineIt == chunks.end() ) {
+		return false;
+	}
+
+	SVG_Nav_FreeMesh();
+	if ( !g_nav_mesh.create( TAG_SVGAME_LEVEL, []( nav_mesh_t *mesh ) {
+		mesh->occupancy_frame = -1;
+	} ) ) {
+		return false;
+	}
+
+	nav_cache_param_chunk_t params = {};
+	{
+		nav_chunk_reader_t reader = { paramIt->second.data(), paramIt->second.size(), 0 };
+		if ( !Nav_ChunkReadValue( &reader, params.cell_size_xy ) ||
+			!Nav_ChunkReadValue( &reader, params.z_quant ) ||
+			!Nav_ChunkReadValue( &reader, params.tile_size ) ||
+			!Nav_ChunkReadValue( &reader, params.max_step ) ||
+			!Nav_ChunkReadValue( &reader, params.max_slope_deg ) ||
+			!Nav_ChunkReadValue( &reader, params.agent_mins ) ||
+			!Nav_ChunkReadValue( &reader, params.agent_maxs ) ||
+			!Nav_ChunkReadValue( &reader, params.num_leafs ) ||
+			!Nav_ChunkReadValue( &reader, params.num_inline_models ) ||
+			!Nav_ChunkReadValue( &reader, params.num_world_tiles ) ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+
+		if ( params.tile_size <= 0 ||
+			params.num_leafs < 0 || params.num_leafs > 1'000'000 ||
+			params.num_inline_models < 0 || params.num_inline_models > 1'000'000 ||
+			params.num_world_tiles < 0 || params.num_world_tiles > 1'000'000 ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+		if ( reader.offset != reader.size ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+
+		const uint32_t calculatedParamsHash = Nav_CalcParamsHash( params );
+		if ( paramsHash != calculatedParamsHash ) {
+			gi.dprintf( "[Nav] cache load failed: PARAM hash mismatch (file=0x%08X calc=0x%08X)\n",
+				paramsHash, calculatedParamsHash );
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+
+		const bool requireHashMatch = nav_cache_require_hash_match && nav_cache_require_hash_match->integer != 0;
+		if ( requireHashMatch ) {
+			const uint32_t runtimeMapHash = Nav_CalcMapHash();
+			if ( mapHash != runtimeMapHash ) {
+				gi.dprintf( "[Nav] cache load failed: map hash mismatch (file=0x%08X runtime=0x%08X)\n",
+					mapHash, runtimeMapHash );
+				SVG_Nav_FreeMesh();
+				return false;
+			}
+
+			if ( !Nav_ParamChunkMatchesActiveCvars( params ) ) {
+				gi.dprintf( "[Nav] cache load failed: nav generation cvars changed; rebake required (set nav_cache_require_hash_match 0 to override)\n" );
+				SVG_Nav_FreeMesh();
+				return false;
+			}
+		}
+
+		g_nav_mesh->cell_size_xy = params.cell_size_xy;
+		g_nav_mesh->z_quant = params.z_quant;
+		g_nav_mesh->tile_size = params.tile_size;
+		g_nav_mesh->max_step = params.max_step;
+		g_nav_mesh->max_slope_deg = params.max_slope_deg;
+		g_nav_mesh->agent_mins = params.agent_mins;
+		g_nav_mesh->agent_maxs = params.agent_maxs;
+		g_nav_mesh->num_leafs = params.num_leafs;
+		g_nav_mesh->num_inline_models = params.num_inline_models;
+	}
+
+	{
+		nav_chunk_reader_t reader = { worldTilesIt->second.data(), worldTilesIt->second.size(), 0 };
+		int32_t numWorldTiles = 0;
+		if ( !Nav_ChunkReadValue( &reader, numWorldTiles ) ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+		if ( numWorldTiles < 0 || numWorldTiles > 1'000'000 ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+		if ( numWorldTiles != params.num_world_tiles ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+
+		g_nav_mesh->world_tiles.clear();
+		g_nav_mesh->world_tile_id_of.clear();
+		g_nav_mesh->world_tiles.reserve( (size_t)numWorldTiles );
+		g_nav_mesh->world_tile_id_of.reserve( (size_t)numWorldTiles * 2u );
+
+		for ( int32_t i = 0; i < numWorldTiles; i++ ) {
+			nav_tile_t tile = {};
+			if ( !Nav_ChunkReadTilePayload( &reader, g_nav_mesh.get(), &tile ) ) {
+				SVG_Nav_FreeMesh();
+				return false;
+			}
+
+			const int32_t tileId = (int32_t)g_nav_mesh->world_tiles.size();
+			g_nav_mesh->world_tiles.push_back( tile );
+			nav_world_tile_key_t key = { tile.tile_x, tile.tile_y };
+			g_nav_mesh->world_tile_id_of[ key ] = tileId;
+		}
+		if ( reader.offset != reader.size ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+	}
+
+	{
+		nav_chunk_reader_t reader = { leafMapIt->second.data(), leafMapIt->second.size(), 0 };
+		int32_t numLeafsChunk = 0;
+		if ( !Nav_ChunkReadValue( &reader, numLeafsChunk ) ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+		if ( numLeafsChunk != g_nav_mesh->num_leafs ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+
+		g_nav_mesh->leaf_data = (nav_leaf_data_t *)gi.TagMallocz( sizeof( nav_leaf_data_t ) * (size_t)g_nav_mesh->num_leafs, TAG_SVGAME_LEVEL );
+		for ( int32_t i = 0; i < g_nav_mesh->num_leafs; i++ ) {
+			nav_leaf_data_t &leaf = g_nav_mesh->leaf_data[ i ];
+			if ( !Nav_ChunkReadValue( &reader, leaf.leaf_index ) ||
+				!Nav_ChunkReadValue( &reader, leaf.num_tiles ) ) {
+				SVG_Nav_FreeMesh();
+				return false;
+			}
+			if ( leaf.num_tiles < 0 || leaf.num_tiles > 1'000'000 ) {
+				SVG_Nav_FreeMesh();
+				return false;
+			}
+
+			leaf.tile_ids = (int32_t *)gi.TagMallocz( sizeof( int32_t ) * (size_t)leaf.num_tiles, TAG_SVGAME_LEVEL );
+			for ( int32_t t = 0; t < leaf.num_tiles; t++ ) {
+				int32_t tileId = -1;
+				if ( !Nav_ChunkReadValue( &reader, tileId ) ) {
+					SVG_Nav_FreeMesh();
+					return false;
+				}
+				if ( tileId < 0 || tileId >= (int32_t)g_nav_mesh->world_tiles.size() ) {
+					SVG_Nav_FreeMesh();
+					return false;
+				}
+				leaf.tile_ids[ t ] = tileId;
+			}
+		}
+		if ( reader.offset != reader.size ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+	}
+
+	{
+		nav_chunk_reader_t reader = { inlineIt->second.data(), inlineIt->second.size(), 0 };
+		int32_t numInlineChunk = 0;
+		if ( !Nav_ChunkReadValue( &reader, numInlineChunk ) ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+		if ( numInlineChunk != g_nav_mesh->num_inline_models ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+
+		if ( g_nav_mesh->num_inline_models > 0 ) {
+			g_nav_mesh->inline_model_data = (nav_inline_model_data_t *)gi.TagMallocz( sizeof( nav_inline_model_data_t ) * (size_t)g_nav_mesh->num_inline_models, TAG_SVGAME_LEVEL );
+			for ( int32_t i = 0; i < g_nav_mesh->num_inline_models; i++ ) {
+				nav_inline_model_data_t &model = g_nav_mesh->inline_model_data[ i ];
+				if ( !Nav_ChunkReadValue( &reader, model.model_index ) ||
+					!Nav_ChunkReadValue( &reader, model.num_tiles ) ) {
+					SVG_Nav_FreeMesh();
+					return false;
+				}
+				if ( model.num_tiles < 0 || model.num_tiles > 1'000'000 ) {
+					SVG_Nav_FreeMesh();
+					return false;
+				}
+
+				if ( model.num_tiles > 0 ) {
+					model.tiles = (nav_tile_t *)gi.TagMallocz( sizeof( nav_tile_t ) * (size_t)model.num_tiles, TAG_SVGAME_LEVEL );
+					for ( int32_t t = 0; t < model.num_tiles; t++ ) {
+						if ( !Nav_ChunkReadTilePayload( &reader, g_nav_mesh.get(), &model.tiles[ t ] ) ) {
+							SVG_Nav_FreeMesh();
+							return false;
+						}
+					}
+				}
+			}
+		}
+		if ( reader.offset != reader.size ) {
+			SVG_Nav_FreeMesh();
+			return false;
+		}
+	}
+
+	return Nav_RebuildInlineRuntimeAfterLoad( g_nav_mesh.get() );
 }
 
 /**
@@ -118,7 +614,21 @@ bool SVG_Nav_LoadVoxelMesh( const char *filename ) {
 		gzclose( f );
 		return false;
 	}
-	if ( magic != NAV_MESH_SAVE_MAGIC || version != NAV_MESH_SAVE_VERSION ) {
+	if ( magic != NAV_MESH_SAVE_MAGIC ) {
+		gzclose( f );
+		return false;
+	}
+
+	if ( version == NAV_MESH_SAVE_VERSION_V2 ) {
+		const bool loaded = Nav_LoadVoxelMeshV2Payload( f );
+		gzclose( f );
+		if ( !loaded ) {
+			SVG_Nav_FreeMesh();
+		}
+		return loaded;
+	}
+
+	if ( version != NAV_MESH_SAVE_VERSION_V1 ) {
 		gzclose( f );
 		return false;
 	}

--- a/src/baseq2rtxp/svgame/nav/svg_nav_path_process.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_path_process.cpp
@@ -9,7 +9,9 @@
 
 // Includes: local and navigation headers.
 #include "svgame/svg_local.h"
+#include <algorithm>
 #include <cstring>
+#include <cmath>
 
 #include "svgame/nav/svg_nav.h"
 #include "svgame/nav/svg_nav_clusters.h"
@@ -22,23 +24,100 @@ extern cvar_t *nav_drop_cap;
 extern cvar_t *nav_debug_draw;
 
 /**
-*	@brief    Build a traversal policy mirroring the provided agent profile.
-*	@param    profile    Agent hull/extents and traversal limits.
-*	@return   Policy whose bounds (bbox, steps, drops, slope) match the profile.
+*	@brief	Resolve the effective drop cap used for path validation/smoothing.
+*	@param	policy	Path policy containing drop constraints.
+*	@return	Drop limit in world units.
 **/
-static svg_nav_path_policy_t SVG_Nav_BuildPolicyFromAgentProfile( const nav_agent_profile_t &profile ) {
-    /**
-    *	Copy profile data into the policy so any later modifications can layer
-    *	on top without mutating the original profile.
-    **/
-    svg_nav_path_policy_t policy = {};
-    policy.agent_mins = profile.mins;
-    policy.agent_maxs = profile.maxs;
-    policy.max_step_height = profile.max_step_height;
-    policy.max_drop_height = profile.max_drop_height;
-    policy.drop_cap = profile.drop_cap;
-    policy.max_slope_deg = profile.max_slope_deg;
-    return policy;
+static float SVG_Nav_ResolveDropCapForPath( const svg_nav_path_policy_t &policy ) {
+	if ( policy.drop_cap > 0.0f ) {
+		return ( float )policy.drop_cap;
+	}
+	if ( policy.cap_drop_height ) {
+		return ( float )policy.max_drop_height;
+	}
+	return nav_drop_cap ? nav_drop_cap->value : 100.0f;
+}
+
+/**
+*	@brief	Check whether all drops within an original waypoint segment satisfy the cap.
+*	@param	points	Original waypoint list (nav-center space).
+*	@param	from	Segment start index.
+*	@param	to		Segment end index.
+*	@param	maxDrop	Maximum permitted downward drop.
+*	@return	True if every intermediate downward transition is within maxDrop.
+**/
+static bool SVG_Nav_PathSegmentRespectsDropCap( const std::vector<Vector3> &points, size_t from, size_t to, float maxDrop ) {
+	if ( to <= ( from + 1 ) || maxDrop <= 0.0f ) {
+		return true;
+	}
+	if ( from >= points.size() || to >= points.size() || from >= to ) {
+		return false;
+	}
+
+	for ( size_t i = from + 1; i <= to; ++i ) {
+		const float dz = points[ i - 1 ].z - points[ i ].z;
+		if ( dz > maxDrop ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+*	@brief	Apply stair-safe LOS shortcut smoothing to nav-center waypoints.
+*	@param	mesh				Navigation mesh used for step/drop validation.
+*	@param	input_points		Original A* points in nav-center space.
+*	@param	agent_mins_feet		Agent bbox mins in feet-origin space.
+*	@param	agent_maxs_feet		Agent bbox maxs in feet-origin space.
+*	@param	policy				Traversal policy used for LOS/drop checks.
+*	@param	out_points			[out] Smoothed output points.
+**/
+static void SVG_Nav_SmoothPathPoints_StairSafeLOS( const nav_mesh_t *mesh, const std::vector<Vector3> &input_points,
+	const Vector3 &agent_mins_feet, const Vector3 &agent_maxs_feet,
+	const svg_nav_path_policy_t &policy, std::vector<Vector3> *out_points ) {
+	if ( !out_points ) {
+		return;
+	}
+
+	*out_points = input_points;
+	if ( !mesh || input_points.size() <= 2 ) {
+		return;
+	}
+
+	// Convert the feet-origin hull into nav-center space for edge tests.
+	const float centerOffsetZ = ( agent_mins_feet.z + agent_maxs_feet.z ) * 0.5f;
+	const Vector3 agent_center_mins = QM_Vector3Subtract( agent_mins_feet, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
+	const Vector3 agent_center_maxs = QM_Vector3Subtract( agent_maxs_feet, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
+	const float maxDrop = SVG_Nav_ResolveDropCapForPath( policy );
+
+	std::vector<Vector3> stringPulled = {};
+	stringPulled.reserve( input_points.size() );
+	stringPulled.push_back( input_points.front() );
+
+	size_t anchor = 0;
+	const size_t totalPoints = input_points.size();
+	while ( anchor + 1 < totalPoints ) {
+		size_t chosen = anchor + 1;
+		for ( size_t candidate = totalPoints - 1; candidate > anchor + 1; --candidate ) {
+			// Keep shortcutting stair-safe by ensuring skipped source segments respect drop caps.
+			if ( !SVG_Nav_PathSegmentRespectsDropCap( input_points, anchor, candidate, maxDrop ) ) {
+				continue;
+			}
+			if ( Nav_CanTraverseStep_ExplicitBBox( mesh, input_points[ anchor ], input_points[ candidate ],
+				agent_center_mins, agent_center_maxs, nullptr, &policy ) ) {
+				chosen = candidate;
+				break;
+			}
+		}
+
+		stringPulled.push_back( input_points[ chosen ] );
+		anchor = chosen;
+	}
+
+	if ( stringPulled.size() >= 2 ) {
+		out_points->swap( stringPulled );
+	}
 }
 
 /**
@@ -72,6 +151,7 @@ void svg_nav_path_process_t::Reset( void ) {
 	last_failure_time = 0_ms;
 	last_failure_pos = {};
 	last_failure_yaw = 0.0f;
+	next_occupancy_replan_time = 0_ms;
 }
 
 /**
@@ -92,21 +172,21 @@ const bool svg_nav_path_process_t::CommitAsyncPathFromPoints( const std::vector<
 		return false;
 	}
 
- /**
-	*    NOTE: Path smoothing temporarily disabled due to a runtime regression
-	*    observed in async commit flow. Revert to committing raw A* points to
-	*    ensure path availability remains correct. The funnel+offset approach
-	*    will be reintroduced after a safer incremental integration.
-	**/
+	const nav_mesh_t *mesh = g_nav_mesh.get();
+	std::vector<Vector3> commitPoints = points;
+	SVG_Nav_SmoothPathPoints_StairSafeLOS( mesh, points, policy.agent_mins, policy.agent_maxs, policy, &commitPoints );
+	if ( commitPoints.empty() ) {
+		return false;
+	}
 
  /**
 	 *	Copy the waypoints into a traversal path owned by this process.
 	 **/
-	const int32_t pointCount = ( int32_t )points.size();
+	const int32_t pointCount = ( int32_t )commitPoints.size();
 	nav_traversal_path_t newPath = {};
 	newPath.num_points = pointCount;
 	newPath.points = ( Vector3 * )gi.TagMallocz( sizeof( Vector3 ) * newPath.num_points, TAG_SVGAME_LEVEL );
-	memcpy( newPath.points, points.data(), sizeof( Vector3 ) * newPath.num_points );
+	memcpy( newPath.points, commitPoints.data(), sizeof( Vector3 ) * newPath.num_points );
 
 	/**
 	 *	Update stored path metadata and reset failure state.
@@ -120,6 +200,7 @@ const bool svg_nav_path_process_t::CommitAsyncPathFromPoints( const std::vector<
 	consecutive_failures = 0;
 	backoff_until = 0_ms;
 	next_rebuild_time = level.time + policy.rebuild_interval;
+	next_occupancy_replan_time = 0_ms;
 	return true;
 }
 
@@ -210,15 +291,22 @@ const bool svg_nav_path_process_t::RebuildPathToWithAgentBBox( const Vector3 &st
 	/**
 	*    Align the working policy with the runtime agent profile.
 	**/
-	const nav_agent_profile_t agentProfile = SVG_Nav_BuildAgentProfileFromCvars();
+	const nav_agent_profile_t resolvedAgentProfile = SVG_Nav_ResolveAgentProfile( g_nav_mesh.get(), &agent_mins, &agent_maxs );
 	svg_nav_path_policy_t resolvedPolicy = policy;
-	const svg_nav_path_policy_t profilePolicy = SVG_Nav_BuildPolicyFromAgentProfile( agentProfile );
-	resolvedPolicy.agent_mins = profilePolicy.agent_mins;
-	resolvedPolicy.agent_maxs = profilePolicy.agent_maxs;
-	resolvedPolicy.max_step_height = profilePolicy.max_step_height;
-	resolvedPolicy.max_drop_height = profilePolicy.max_drop_height;
-	resolvedPolicy.drop_cap = profilePolicy.drop_cap;
-	resolvedPolicy.max_slope_deg = profilePolicy.max_slope_deg;
+	resolvedPolicy.agent_mins = resolvedAgentProfile.mins;
+	resolvedPolicy.agent_maxs = resolvedAgentProfile.maxs;
+	if ( resolvedPolicy.max_step_height <= 0.0 ) {
+		resolvedPolicy.max_step_height = resolvedAgentProfile.max_step_height;
+	}
+	if ( resolvedPolicy.max_drop_height <= 0.0 ) {
+		resolvedPolicy.max_drop_height = resolvedAgentProfile.max_drop_height;
+	}
+	if ( resolvedPolicy.drop_cap <= 0.0 ) {
+		resolvedPolicy.drop_cap = resolvedAgentProfile.drop_cap;
+	}
+	if ( resolvedPolicy.max_slope_deg <= 0.0 ) {
+		resolvedPolicy.max_slope_deg = resolvedAgentProfile.max_slope_deg;
+	}
 
 	/**
 	*	Pre-check: warn if the vertical gap already exceeds the effective step height.
@@ -347,10 +435,10 @@ const bool svg_nav_path_process_t::RebuildPathToWithAgentBBox( const Vector3 &st
 	*		The nav system stores/queries points in a hull-center coordinate frame.
 	**/
 	// Compute center offset (feet-origin -> center-origin).
-	const float centerOffsetZ = ( agent_mins.z + agent_maxs.z ) * 0.5f;
+	const float centerOffsetZ = ( resolvedPolicy.agent_mins.z + resolvedPolicy.agent_maxs.z ) * 0.5f;
 	// Convert mins/maxs into center-origin space.
-	const Vector3 agent_center_mins = QM_Vector3Subtract( agent_mins, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
-	const Vector3 agent_center_maxs = QM_Vector3Subtract( agent_maxs, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
+	const Vector3 agent_center_mins = QM_Vector3Subtract( resolvedPolicy.agent_mins, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
+	const Vector3 agent_center_maxs = QM_Vector3Subtract( resolvedPolicy.agent_maxs, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
 	// Convert start/goal into center-origin space.
 	const Vector3 start_center = QM_Vector3Add( start_origin, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
 	const Vector3 goal_center = QM_Vector3Add( goal_origin, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
@@ -388,9 +476,7 @@ const bool svg_nav_path_process_t::RebuildPathToWithAgentBBox( const Vector3 &st
 	*        per-policy max drop when dropping is capped. Fall back to the global
 	*        drop cap when no policy value is configured.
 	**/
-	const float maxDrop = ( resolvedPolicy.drop_cap > 0.0f )
-	    ? ( float )resolvedPolicy.drop_cap
-	    : ( resolvedPolicy.cap_drop_height ? ( float )resolvedPolicy.max_drop_height : ( nav_drop_cap ? nav_drop_cap->value : 100.0f ) );
+	const float maxDrop = SVG_Nav_ResolveDropCapForPath( resolvedPolicy );
 	if ( ok && path.num_points > 1 && path.points ) {
 		// Scan each segment for excessive vertical drop.
 		for ( int32_t i = 1; i < path.num_points; ++i ) {
@@ -408,6 +494,22 @@ const bool svg_nav_path_process_t::RebuildPathToWithAgentBBox( const Vector3 &st
 	*	Commit success or revert on failure.
 	**/
 	if ( ok && dropLimitOk ) {
+		// Convert and smooth raw A* points so sync/async paths share the same stabilization.
+		std::vector<Vector3> rawPoints = {};
+		rawPoints.reserve( path.num_points );
+		for ( int32_t i = 0; i < path.num_points; ++i ) {
+			rawPoints.push_back( path.points[ i ] );
+		}
+
+		std::vector<Vector3> smoothedPoints = rawPoints;
+		SVG_Nav_SmoothPathPoints_StairSafeLOS( g_nav_mesh.get(), rawPoints, resolvedPolicy.agent_mins, resolvedPolicy.agent_maxs, resolvedPolicy, &smoothedPoints );
+		if ( !smoothedPoints.empty() ) {
+			SVG_Nav_FreeTraversalPath( &path );
+			path.num_points = ( int32_t )smoothedPoints.size();
+			path.points = ( Vector3 * )gi.TagMallocz( sizeof( Vector3 ) * path.num_points, TAG_SVGAME_LEVEL );
+			memcpy( path.points, smoothedPoints.data(), sizeof( Vector3 ) * path.num_points );
+		}
+
 		// Free old path now that we have a valid replacement.
 		SVG_Nav_FreeTraversalPath( &oldPath );
 		// Store feet-origin start/goal (callers interact in entity space).
@@ -418,6 +520,7 @@ const bool svg_nav_path_process_t::RebuildPathToWithAgentBBox( const Vector3 &st
 		// Reset failure tracking.
 		consecutive_failures = 0;
 		backoff_until = 0_ms;
+		next_occupancy_replan_time = 0_ms;
 		// Throttle subsequent rebuilds.
 		next_rebuild_time = level.time + policy.rebuild_interval;
 		return true;
@@ -462,6 +565,51 @@ const bool svg_nav_path_process_t::CanRebuild( const svg_nav_path_policy_t &poli
 	( void )policy;
 	// Rebuild is permitted only if we are past both throttle and backoff times.
 	return level.time >= next_rebuild_time && level.time >= backoff_until;
+}
+
+/**
+*	@brief	Check whether upcoming waypoints are congested and should trigger a rebuild.
+**/
+const bool svg_nav_path_process_t::ShouldRebuildForOccupancy( const svg_nav_path_policy_t &policy ) const {
+	if ( !policy.enable_occupancy_replan ) {
+		return false;
+	}
+	if ( level.time < next_occupancy_replan_time ) {
+		return false;
+	}
+	if ( path.num_points <= 0 || !path.points ) {
+		return false;
+	}
+
+	const nav_mesh_t *mesh = g_nav_mesh.get();
+	if ( !mesh ) {
+		return false;
+	}
+
+	const int32_t lookaheadCount = std::max( 1, policy.occupancy_lookahead_points );
+	const int32_t softThreshold = std::max( 1, policy.occupancy_soft_cost_replan_threshold );
+	const int32_t startIndex = std::max( 0, std::min( path_index, path.num_points - 1 ) );
+
+	int32_t inspected = 0;
+	for ( int32_t idx = startIndex; idx < path.num_points && inspected < lookaheadCount; ++idx, ++inspected ) {
+		const Vector3 &navPoint = path.points[ idx ];
+		if ( policy.occupancy_replan_on_blocked && SVG_Nav_Occupancy_BlockedForPosition( mesh, navPoint, true ) ) {
+			return true;
+		}
+		const int32_t softCost = SVG_Nav_Occupancy_SoftCostForPosition( mesh, navPoint, true );
+		if ( softCost >= softThreshold ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+*	@brief	Start occupancy-triggered rebuild cooldown to avoid requeue spam.
+**/
+void svg_nav_path_process_t::MarkOccupancyRebuildScheduled( const svg_nav_path_policy_t &policy ) {
+	next_occupancy_replan_time = level.time + policy.occupancy_replan_cooldown;
 }
 /**
 *	@brief	Determine if the path should be rebuilt based on the goal's 2D distance change.

--- a/src/baseq2rtxp/svgame/nav/svg_nav_path_process.h
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_path_process.h
@@ -113,6 +113,20 @@ struct svg_nav_path_policy_t {
 	//!		remains stable on stairs while still allowing large Z deltas to select the
 	//!		correct floor.
 	double layer_select_prefer_z_threshold = 16.0;
+
+	/**
+	*	Dynamic occupancy replanning controls:
+	**/
+	//! Enable occupancy-triggered rebuilds when the active corridor is congested.
+	bool enable_occupancy_replan = true;
+	//! Soft-cost threshold (inclusive) that triggers an occupancy replan.
+	int32_t occupancy_soft_cost_replan_threshold = 6;
+	//! Number of upcoming waypoints inspected for occupancy pressure.
+	int32_t occupancy_lookahead_points = 4;
+	//! Cooldown to prevent occupancy-triggered rebuild spam.
+	QMTime occupancy_replan_cooldown = 150_ms;
+	//! If true, trigger immediate replan when a looked-ahead node is hard blocked.
+	bool occupancy_replan_on_blocked = true;
 };
 
 /**
@@ -155,6 +169,8 @@ struct svg_nav_path_process_t {
 	bool rebuild_in_progress = false;
 	//! Stores the handle of the pending async rebuild request for cancellation/logging.
 	int32_t pending_request_handle = 0;
+	//! Next timestamp at which occupancy-triggered rebuilds are allowed.
+	QMTime next_occupancy_replan_time = 0_ms;
 
 	/**
 	*	@brief	Policy for path processing and follow behavior.
@@ -192,6 +208,14 @@ struct svg_nav_path_process_t {
 	*	@brief	Used to determine if a path rebuild can be attempted at this time.
 	**/
 	const bool CanRebuild( const svg_nav_path_policy_t &policy ) const;
+	/**
+	*	@brief	Check if occupancy pressure ahead warrants rebuilding.
+	**/
+	const bool ShouldRebuildForOccupancy( const svg_nav_path_policy_t &policy ) const;
+	/**
+	*	@brief	Apply occupancy cooldown after scheduling a rebuild.
+	**/
+	void MarkOccupancyRebuildScheduled( const svg_nav_path_policy_t &policy );
 	/**
 	*	@brief	Determine if the path should be rebuilt based on the goal's 2D distance change.
 	*	@return	True if the path should be rebuilt.

--- a/src/baseq2rtxp/svgame/nav/svg_nav_request.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_request.cpp
@@ -37,13 +37,23 @@ static cvar_t *s_nav_requests_per_frame = nullptr;
 //! Per-request expansion budget cvar.
 static cvar_t *s_nav_expansions_per_request = nullptr;
 
-static void NavRequest_LogQueueDiagnostics( int32_t queueBefore, int32_t queueAfter, int32_t processed, int32_t requestBudget, int32_t remainingExpansions );
+//! Per-frame queue time budget cvar (milliseconds). <= 0 disables time cap.
+static cvar_t *s_nav_queue_budget_ms = nullptr;
+
+//! Runtime profiling counters for async queue dashboards.
+static nav_async_queue_profile_t s_nav_async_profile = {};
+//! Round-robin cursor for fair queue service under load.
+static int32_t s_nav_queue_rr_cursor = 0;
+
+static void NavRequest_LogQueueDiagnostics( int32_t queueBefore, int32_t queueAfter, int32_t processed, int32_t requestBudget,
+	int32_t remainingExpansions, int32_t expansionsUsed, uint64_t frameElapsedMs, int32_t queueBudgetMs );
 static nav_request_entry_t *NavRequest_FindEntryByHandle( nav_request_handle_t handle );
 static nav_request_entry_t *NavRequest_FindEntryForProcess( svg_nav_path_process_t *process );
 static bool NavRequest_PrepareAStarForEntry( nav_request_entry_t &entry );
 static void NavRequest_ClearProcessMarkers( nav_request_entry_t &entry );
 static bool NavRequest_FinalizePathForEntry( nav_request_entry_t &entry );
 static void NavRequest_HandleFailure( nav_request_entry_t &entry );
+static void NavRequest_UpdateQueuePeakDepth( void );
 
 /**
 *    @brief    Register cvars that control async request processing and diagnostics.
@@ -57,8 +67,19 @@ void SVG_Nav_RequestQueue_RegisterCvars( void ) {
 	s_nav_nav_async_enable = gi.cvar( "nav_nav_async_enable", "1", 0 );
 	s_nav_requests_per_frame = gi.cvar( "nav_requests_per_frame", "4", 0 );
 	s_nav_expansions_per_request = gi.cvar( "nav_expansions_per_request", "512", 0 );
+	s_nav_queue_budget_ms = gi.cvar( "nav_queue_budget_ms", "2", 0 );
 	nav_nav_async_queue_mode = gi.cvar( "nav_nav_async_queue_mode", "1", 0 );
 	s_nav_nav_async_log_stats = gi.cvar( "nav_nav_async_log_stats", "1", 0 );
+}
+
+/**
+*    @brief    Keep the peak queue depth counter in sync with current queue size.
+**/
+static void NavRequest_UpdateQueuePeakDepth( void ) {
+	const int32_t depth = ( int32_t )s_nav_request_queue.size();
+	if ( depth > s_nav_async_profile.queue_peak_depth ) {
+		s_nav_async_profile.queue_peak_depth = depth;
+	}
 }
 
 /**
@@ -164,6 +185,8 @@ nav_request_handle_t SVG_Nav_RequestPathAsync( svg_nav_path_process_t *pathProce
 		existing->agent_maxs = agent_maxs;
 		existing->force = existing->force || force;
 		existing->status = nav_request_status_t::Queued;
+		existing->enqueue_time_ms = gi.GetRealSystemTime();
+		s_nav_async_profile.total_refreshed++;
         if ( s_nav_nav_async_log_stats && s_nav_nav_async_log_stats->integer != 0 ) {
 			gi.dprintf( "[NavAsync][Queue] Refreshed existing entry handle=%d for ent_process=%p (queued)\n",
 				existing->handle, ( void * )existing->path_process );
@@ -189,11 +212,14 @@ nav_request_handle_t SVG_Nav_RequestPathAsync( svg_nav_path_process_t *pathProce
 	entry.force = force;
 	entry.status = nav_request_status_t::Queued;
 	entry.handle = handle;
+	entry.enqueue_time_ms = gi.GetRealSystemTime();
 
 	/**
 	*    Enqueue the new entry for future processing ticks.
 	**/
 	s_nav_request_queue.push_back( entry );
+	s_nav_async_profile.total_enqueued++;
+	NavRequest_UpdateQueuePeakDepth();
     // Lightweight diagnostic: log new enqueue when async logging is desired.
 	if ( s_nav_nav_async_log_stats && s_nav_nav_async_log_stats->integer != 0 ) {
 		gi.dprintf( "[NavAsync][Queue] Enqueued handle=%d for ent_process=%p start=(%.1f %.1f %.1f) goal=(%.1f %.1f %.1f) force=%d\n",
@@ -230,6 +256,7 @@ void SVG_Nav_CancelRequest( nav_request_handle_t handle ) {
 	}
 
 	entry->status = nav_request_status_t::Cancelled;
+	s_nav_async_profile.total_cancelled++;
 }
 
 /**
@@ -285,24 +312,37 @@ void SVG_Nav_ProcessRequestQueue( void ) {
 	**/
 	const int32_t requestBudget = SVG_Nav_GetAsyncRequestBudget();
 	const int32_t expansionsPerRequest = SVG_Nav_GetAsyncRequestExpansions();
+	const int32_t queueBudgetMs = SVG_Nav_GetAsyncQueueFrameBudgetMs();
 	const int64_t totalExpansions = ( int64_t )expansionsPerRequest * requestBudget;
 	int32_t remainingExpansions = ( int32_t )std::min( totalExpansions, ( int64_t )std::numeric_limits<int32_t>::max() );
 	int32_t processed = 0;
+	int32_t expansionsUsed = 0;
 	const int32_t queueBefore = ( int32_t )s_nav_request_queue.size();
 	const uint64_t queueStartMs = gi.GetRealSystemTime();
-	const uint64_t queueBudgetMs = 2;
+	const int32_t queueCount = ( int32_t )s_nav_request_queue.size();
+	int32_t scanned = 0;
+	if ( queueCount > 0 ) {
+		if ( s_nav_queue_rr_cursor < 0 || s_nav_queue_rr_cursor >= queueCount ) {
+			s_nav_queue_rr_cursor = 0;
+		}
+	}
 
 	/**
 	*    Iterate queue entries while honoring request, expansion, and time budgets.
+	*    Start from a round-robin cursor for fair service under load.
 	**/
-	for ( nav_request_entry_t &entry : s_nav_request_queue ) {
+	while ( scanned < queueCount ) {
 		if ( processed >= requestBudget || remainingExpansions <= 0 ) {
 			break;
 		}
 		const uint64_t queueElapsedMs = gi.GetRealSystemTime() - queueStartMs;
-		if ( queueBudgetMs > 0 && queueElapsedMs > queueBudgetMs ) {
+		if ( queueBudgetMs > 0 && queueElapsedMs >= ( uint64_t )queueBudgetMs ) {
 			break;
 		}
+
+		const int32_t entryIndex = ( s_nav_queue_rr_cursor + scanned ) % queueCount;
+		scanned++;
+		nav_request_entry_t &entry = s_nav_request_queue[ entryIndex ];
 
 		if ( entry.status == nav_request_status_t::Completed || entry.status == nav_request_status_t::Failed || entry.status == nav_request_status_t::Cancelled ) {
 			NavRequest_ClearProcessMarkers( entry );
@@ -312,6 +352,8 @@ void SVG_Nav_ProcessRequestQueue( void ) {
 		if ( entry.status == nav_request_status_t::Queued ) {
           if ( !NavRequest_PrepareAStarForEntry( entry ) ) {
 				entry.status = nav_request_status_t::Failed;
+				s_nav_async_profile.total_prepare_failures++;
+				s_nav_async_profile.total_failed++;
 				NavRequest_HandleFailure( entry );
 				NavRequest_ClearProcessMarkers( entry );
 				Nav_AStar_Reset( &entry.a_star );
@@ -339,6 +381,8 @@ void SVG_Nav_ProcessRequestQueue( void ) {
 				break;
 			}
 			remainingExpansions -= expansionsToUse;
+			expansionsUsed += expansionsToUse;
+			s_nav_async_profile.total_expansions += expansionsToUse;
 			starStatus = Nav_AStar_Step( &entry.a_star, expansionsToUse );
 		}
 
@@ -346,16 +390,21 @@ void SVG_Nav_ProcessRequestQueue( void ) {
 		*    Track that we touched this request this frame.
 		**/
 		processed++;
+		s_nav_async_profile.total_processed++;
 
 		if ( starStatus == nav_a_star_status_t::Completed ) {
 			const bool commitOk = NavRequest_FinalizePathForEntry( entry );
 			entry.status = commitOk ? nav_request_status_t::Completed : nav_request_status_t::Failed;
 			if ( !commitOk ) {
+				s_nav_async_profile.total_failed++;
 				NavRequest_HandleFailure( entry );
+			} else {
+				s_nav_async_profile.total_completed++;
 			}
 			NavRequest_ClearProcessMarkers( entry );
 		} else if ( starStatus == nav_a_star_status_t::Failed ) {
 			entry.status = nav_request_status_t::Failed;
+			s_nav_async_profile.total_failed++;
 			NavRequest_HandleFailure( entry );
 			NavRequest_ClearProcessMarkers( entry );
 		}
@@ -363,6 +412,30 @@ void SVG_Nav_ProcessRequestQueue( void ) {
 		if ( entry.status != nav_request_status_t::Running ) {
 			Nav_AStar_Reset( &entry.a_star );
 		}
+	}
+	if ( queueCount > 0 ) {
+		s_nav_queue_rr_cursor = ( s_nav_queue_rr_cursor + scanned ) % queueCount;
+	}
+
+	/**
+	*    Collect queue wait-time samples for entries that reached a terminal state.
+	**/
+	const uint64_t queueNowMs = gi.GetRealSystemTime();
+	for ( const nav_request_entry_t &entry : s_nav_request_queue ) {
+		if ( entry.status != nav_request_status_t::Completed
+			&& entry.status != nav_request_status_t::Failed
+			&& entry.status != nav_request_status_t::Cancelled ) {
+			continue;
+		}
+
+		if ( entry.enqueue_time_ms == 0 || queueNowMs < entry.enqueue_time_ms ) {
+			continue;
+		}
+
+		const uint64_t waitMs = queueNowMs - entry.enqueue_time_ms;
+		s_nav_async_profile.total_queue_wait_ms += waitMs;
+		s_nav_async_profile.max_queue_wait_ms = std::max( s_nav_async_profile.max_queue_wait_ms, waitMs );
+		s_nav_async_profile.queue_wait_samples++;
 	}
 
 	/**
@@ -375,8 +448,29 @@ void SVG_Nav_ProcessRequestQueue( void ) {
 				|| entry.status == nav_request_status_t::Cancelled;
 		} ),
 		s_nav_request_queue.end() );
+	if ( s_nav_request_queue.empty() ) {
+		s_nav_queue_rr_cursor = 0;
+	} else if ( s_nav_queue_rr_cursor >= ( int32_t )s_nav_request_queue.size() ) {
+		s_nav_queue_rr_cursor %= ( int32_t )s_nav_request_queue.size();
+	}
 	const int32_t queueAfter = ( int32_t )s_nav_request_queue.size();
-	NavRequest_LogQueueDiagnostics( queueBefore, queueAfter, processed, requestBudget, remainingExpansions );
+	const uint64_t frameElapsedMs = gi.GetRealSystemTime() - queueStartMs;
+
+	s_nav_async_profile.queue_depth = queueAfter;
+	s_nav_async_profile.last_frame_queue_before = queueBefore;
+	s_nav_async_profile.last_frame_queue_after = queueAfter;
+	s_nav_async_profile.last_frame_processed = processed;
+	s_nav_async_profile.last_frame_expansions = expansionsUsed;
+	s_nav_async_profile.last_frame_elapsed_ms = frameElapsedMs;
+	s_nav_async_profile.last_frame_request_budget = requestBudget;
+	s_nav_async_profile.last_frame_expansion_budget = expansionsPerRequest;
+	s_nav_async_profile.last_frame_queue_budget_ms = queueBudgetMs;
+	if ( queueBudgetMs > 0 && frameElapsedMs >= ( uint64_t )queueBudgetMs ) {
+		s_nav_async_profile.frame_over_budget_count++;
+	}
+	NavRequest_UpdateQueuePeakDepth();
+
+	NavRequest_LogQueueDiagnostics( queueBefore, queueAfter, processed, requestBudget, remainingExpansions, expansionsUsed, frameElapsedMs, queueBudgetMs );
 }
 
 /**
@@ -402,41 +496,27 @@ static bool NavRequest_PrepareAStarForEntry( nav_request_entry_t &entry ) {
 	*    Align policy constraints with the agent hull profile before running A*.
 	**/
 	entry.resolved_policy = entry.policy;
-  const nav_agent_profile_t agentProfile = SVG_Nav_BuildAgentProfileFromCvars();
-	// Determine whether the mesh provides a valid agent hull to align with.
-	const bool meshAgentValid = ( mesh->agent_maxs.z > mesh->agent_mins.z )
-		&& ( mesh->agent_maxs.x > mesh->agent_mins.x )
-		&& ( mesh->agent_maxs.y > mesh->agent_mins.y );
-	// Validate the cvar-driven agent profile before using it as a fallback.
-	const bool profileValid = ( agentProfile.maxs.z > agentProfile.mins.z )
-		&& ( agentProfile.maxs.x > agentProfile.mins.x )
-		&& ( agentProfile.maxs.y > agentProfile.mins.y );
-
-	/**
-	*    Resolve the agent bounds that should drive center offsets and traversal.
-	*        Prefer mesh-authored hull sizes so navigation queries stay aligned.
-	**/
-	Vector3 resolvedAgentMins = entry.agent_mins;
-	Vector3 resolvedAgentMaxs = entry.agent_maxs;
-	// Prefer the mesh agent bounds when they are valid.
-	if ( meshAgentValid ) {
-		resolvedAgentMins = mesh->agent_mins;
-		resolvedAgentMaxs = mesh->agent_maxs;
-	} else if ( profileValid ) {
-		// Fall back to the cvar profile when the mesh is unavailable.
-		resolvedAgentMins = agentProfile.mins;
-		resolvedAgentMaxs = agentProfile.maxs;
-	}
+	const nav_agent_profile_t resolvedAgentProfile = SVG_Nav_ResolveAgentProfile( mesh, &entry.agent_mins, &entry.agent_maxs );
+	Vector3 resolvedAgentMins = resolvedAgentProfile.mins;
+	Vector3 resolvedAgentMaxs = resolvedAgentProfile.maxs;
 
 	/**
 	*    Update the resolved policy with the chosen agent profile and traversal limits.
 	**/
 	entry.resolved_policy.agent_mins = resolvedAgentMins;
 	entry.resolved_policy.agent_maxs = resolvedAgentMaxs;
-	entry.resolved_policy.max_step_height = meshAgentValid ? mesh->max_step : agentProfile.max_step_height;
-	entry.resolved_policy.max_drop_height = agentProfile.max_drop_height;
-	entry.resolved_policy.drop_cap = agentProfile.drop_cap;
-	entry.resolved_policy.max_slope_deg = meshAgentValid ? mesh->max_slope_deg : agentProfile.max_slope_deg;
+	if ( entry.resolved_policy.max_step_height <= 0.0 ) {
+		entry.resolved_policy.max_step_height = resolvedAgentProfile.max_step_height;
+	}
+	if ( entry.resolved_policy.max_drop_height <= 0.0 ) {
+		entry.resolved_policy.max_drop_height = resolvedAgentProfile.max_drop_height;
+	}
+	if ( entry.resolved_policy.drop_cap <= 0.0 ) {
+		entry.resolved_policy.drop_cap = resolvedAgentProfile.drop_cap;
+	}
+	if ( entry.resolved_policy.max_slope_deg <= 0.0 ) {
+		entry.resolved_policy.max_slope_deg = resolvedAgentProfile.max_slope_deg;
+	}
 
  /**
 	*    Compute center offsets using the resolved agent bounds for consistency.
@@ -606,55 +686,8 @@ static bool NavRequest_FinalizePathForEntry( nav_request_entry_t &entry ) {
 		return false;
 	}
 
-	const float centerOffsetZ = ( entry.agent_mins.z + entry.agent_maxs.z ) * 0.5f;
- std::vector<Vector3> smoothedPoints = points;
-	const nav_mesh_t *mesh = g_nav_mesh.get();
-	if ( mesh && smoothedPoints.size() > 2 ) {
-		/**
-		*    Apply a greedy corridor string-pull plus a small lateral offset to
-		*    reduce corner hugging without modifying the navmesh. This operates on
-		*    nav-center waypoints before they are copied into the path process.
-		**/
-		const Vector3 agent_center_mins = QM_Vector3Subtract( entry.agent_mins, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
-		const Vector3 agent_center_maxs = QM_Vector3Subtract( entry.agent_maxs, Vector3{ 0.0f, 0.0f, centerOffsetZ } );
-
-		std::vector<Vector3> stringPulled;
-		stringPulled.reserve( smoothedPoints.size() );
-		stringPulled.push_back( smoothedPoints.front() );
-		size_t anchor = 0;
-		const size_t totalPoints = smoothedPoints.size();
-		while ( anchor + 1 < totalPoints ) {
-			size_t chosen = anchor + 1;
-			for ( size_t candidate = totalPoints - 1; candidate > anchor; --candidate ) {
-				if ( Nav_CanTraverseStep_ExplicitBBox( mesh, smoothedPoints[ anchor ], smoothedPoints[ candidate ], agent_center_mins, agent_center_maxs, nullptr, &entry.resolved_policy ) ) {
-					chosen = candidate;
-					break;
-				}
-			}
-			stringPulled.push_back( smoothedPoints[ chosen ] );
-			anchor = chosen;
-		}
-
-		const float agent_half_width = std::max( fabsf( entry.agent_mins.x ), fabsf( entry.agent_maxs.x ) );
-		const float max_lateral_offset = std::min( agent_half_width, 32.0f );
-		for ( size_t idx = 1; idx + 1 < stringPulled.size(); ++idx ) {
-			const Vector3 &prev = stringPulled[ idx - 1 ];
-			const Vector3 &next = stringPulled[ idx + 1 ];
-			Vector3 corridorCenter = QM_Vector3Add( prev, next ) * 0.5f;
-			Vector3 deviation = QM_Vector3Subtract( corridorCenter, stringPulled[ idx ] );
-			const float deviationLen = QM_Vector3Length( deviation );
-			if ( deviationLen > 0.001f ) {
-				const float offsetFrac = std::min( max_lateral_offset / deviationLen, 0.5f );
-				stringPulled[ idx ] = QM_Vector3Add( stringPulled[ idx ], deviation * offsetFrac );
-			}
-		}
-
-		if ( stringPulled.size() > 1 ) {
-			smoothedPoints.swap( stringPulled );
-		}
-	}
-
-	const bool committed = process->CommitAsyncPathFromPoints( smoothedPoints, entry.start, entry.goal, centerOffsetZ, entry.resolved_policy );
+	const float centerOffsetZ = ( entry.resolved_policy.agent_mins.z + entry.resolved_policy.agent_maxs.z ) * 0.5f;
+	const bool committed = process->CommitAsyncPathFromPoints( points, entry.start, entry.goal, centerOffsetZ, entry.resolved_policy );
 	if ( committed ) {
 		gi.dprintf( "[DEBUG][NavAsync] Finalize: commit succeeded (handle=%d points=%d)\n", entry.handle, ( int )points.size() );
 	} else {
@@ -688,20 +721,22 @@ static void NavRequest_HandleFailure( nav_request_entry_t &entry ) {
 *    @brief    Emit diagnostics summarizing the async navigation request queue state.
 *    @note     Enabled via the `nav_nav_async_log_stats` cvar when troubleshooting queue behavior.
 **/
-static void NavRequest_LogQueueDiagnostics( int32_t queueBefore, int32_t queueAfter, int32_t processed, int32_t requestBudget, int32_t remainingExpansions ) {
+static void NavRequest_LogQueueDiagnostics( int32_t queueBefore, int32_t queueAfter, int32_t processed, int32_t requestBudget,
+	int32_t remainingExpansions, int32_t expansionsUsed, uint64_t frameElapsedMs, int32_t queueBudgetMs ) {
 	if ( !s_nav_nav_async_log_stats || s_nav_nav_async_log_stats->integer == 0 ) {
 		return;
 	}
 
-	if ( queueBefore != 0 && queueAfter != 0 ) {
-		gi.dprintf( "[NavAsync][Stats] queue_before=%d queue_after=%d processed=%d request_budget=%d expansions_remaining=%d queue_mode=%d\n",
-			queueBefore,
-			queueAfter,
-			processed,
-			requestBudget,
-			remainingExpansions,
-			nav_nav_async_queue_mode ? nav_nav_async_queue_mode->integer : 0 );
-	}
+	gi.dprintf( "[NavAsync][Stats] queue_before=%d queue_after=%d processed=%d request_budget=%d expansions_used=%d expansions_remaining=%d elapsed_ms=%llu queue_budget_ms=%d queue_mode=%d\n",
+		queueBefore,
+		queueAfter,
+		processed,
+		requestBudget,
+		expansionsUsed,
+		remainingExpansions,
+		( unsigned long long )frameElapsedMs,
+		queueBudgetMs,
+		nav_nav_async_queue_mode ? nav_nav_async_queue_mode->integer : 0 );
 }
 
 /**
@@ -728,4 +763,34 @@ int32_t SVG_Nav_GetAsyncRequestExpansions( void ) {
 	SVG_Nav_RequestQueue_RegisterCvars();
 	const int32_t budget = s_nav_expansions_per_request ? s_nav_expansions_per_request->integer : 1;
 	return std::max( 1, budget );
+}
+
+/**
+*    @brief    Retrieve the configured per-frame queue time budget in milliseconds.
+**/
+int32_t SVG_Nav_GetAsyncQueueFrameBudgetMs( void ) {
+	SVG_Nav_RequestQueue_RegisterCvars();
+	return s_nav_queue_budget_ms ? s_nav_queue_budget_ms->integer : 0;
+}
+
+/**
+*    @brief    Copy async queue profile counters for external dashboard consumers.
+**/
+void SVG_Nav_GetAsyncQueueProfile( nav_async_queue_profile_t *outProfile ) {
+	if ( !outProfile ) {
+		return;
+	}
+
+	*outProfile = s_nav_async_profile;
+	outProfile->queue_depth = ( int32_t )s_nav_request_queue.size();
+}
+
+/**
+*    @brief    Reset async queue profiling counters.
+**/
+void SVG_Nav_ResetAsyncQueueProfile( void ) {
+	s_nav_async_profile = {};
+	s_nav_async_profile.queue_depth = ( int32_t )s_nav_request_queue.size();
+	NavRequest_UpdateQueuePeakDepth();
+	s_nav_queue_rr_cursor = 0;
 }

--- a/src/baseq2rtxp/svgame/nav/svg_nav_request.h
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_request.h
@@ -46,6 +46,35 @@ struct nav_request_entry_t {
    nav_a_star_state_t a_star = {};
 	bool force = false;
 	nav_request_handle_t handle = 0;
+	uint64_t enqueue_time_ms = 0;
+};
+
+/**
+*    @brief    Runtime profiling snapshot for the async navigation queue.
+**/
+struct nav_async_queue_profile_t {
+	int32_t queue_depth = 0;
+	int32_t queue_peak_depth = 0;
+	int32_t total_enqueued = 0;
+	int32_t total_refreshed = 0;
+	int32_t total_processed = 0;
+	int32_t total_completed = 0;
+	int32_t total_failed = 0;
+	int32_t total_cancelled = 0;
+	int32_t total_prepare_failures = 0;
+	int64_t total_expansions = 0;
+	uint64_t total_queue_wait_ms = 0;
+	uint64_t max_queue_wait_ms = 0;
+	int32_t queue_wait_samples = 0;
+	int32_t last_frame_queue_before = 0;
+	int32_t last_frame_queue_after = 0;
+	int32_t last_frame_processed = 0;
+	int32_t last_frame_expansions = 0;
+	uint64_t last_frame_elapsed_ms = 0;
+	int32_t last_frame_request_budget = 0;
+	int32_t last_frame_expansion_budget = 0;
+	int32_t last_frame_queue_budget_ms = 0;
+	int32_t frame_over_budget_count = 0;
 };
 
 /**
@@ -111,3 +140,19 @@ int32_t SVG_Nav_GetAsyncRequestBudget( void );
 *    @return   At least one expansion unit (clamped to 1).
 **/
 int32_t SVG_Nav_GetAsyncRequestExpansions( void );
+
+/**
+*    @brief    Retrieve the configured per-frame queue time budget (milliseconds).
+*    @note     Values <= 0 disable the time budget cap for the queue tick.
+**/
+int32_t SVG_Nav_GetAsyncQueueFrameBudgetMs( void );
+
+/**
+*    @brief    Snapshot async queue profiling counters for dashboards/commands.
+**/
+void SVG_Nav_GetAsyncQueueProfile( nav_async_queue_profile_t *outProfile );
+
+/**
+*    @brief    Reset async queue profiling counters without clearing queued work.
+**/
+void SVG_Nav_ResetAsyncQueueProfile( void );

--- a/src/baseq2rtxp/svgame/nav/svg_nav_save.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_save.cpp
@@ -22,28 +22,160 @@
 #endif
 
 #include <cstdint>
+#include <vector>
 
 static constexpr uint32_t NAV_MESH_SAVE_MAGIC = 0x56414E53; // "VANS"
-static constexpr uint32_t NAV_MESH_SAVE_VERSION = 1;
+static constexpr uint32_t NAV_MESH_SAVE_VERSION = 2;
+static constexpr uint32_t NAV_MESH_SAVE_ENDIAN_MARKER = 0x12345678;
+
+static constexpr uint32_t Nav_FourCC( const char a, const char b, const char c, const char d ) {
+	return (uint32_t)(uint8_t)a |
+		( (uint32_t)(uint8_t)b << 8 ) |
+		( (uint32_t)(uint8_t)c << 16 ) |
+		( (uint32_t)(uint8_t)d << 24 );
+}
+
+static constexpr uint32_t NAV_CHUNK_PARAM = Nav_FourCC( 'P', 'A', 'R', 'M' );
+static constexpr uint32_t NAV_CHUNK_WORLD_TILES = Nav_FourCC( 'W', 'T', 'I', 'L' );
+static constexpr uint32_t NAV_CHUNK_LEAF_MAP = Nav_FourCC( 'L', 'E', 'A', 'F' );
+static constexpr uint32_t NAV_CHUNK_INLINE_MODELS = Nav_FourCC( 'I', 'M', 'O', 'D' );
+
+static uint32_t Nav_Hash32( const void *data, const size_t size ) {
+	const uint8_t *bytes = (const uint8_t *)data;
+	uint32_t hash = 2166136261u;
+	for ( size_t i = 0; i < size; i++ ) {
+		hash ^= bytes[ i ];
+		hash *= 16777619u;
+	}
+	return hash;
+}
 
 /**
 *	@brief	Write raw bytes to a (possibly gzipped) file.
 *	@return	True if all bytes were written.
 **/
 static bool Nav_Write( gzFile f, const void *data, const size_t size ) {
-	if ( !f || !data || size == 0 ) {
+	if ( !f || ( !data && size > 0 ) ) {
 		return false;
 	}
-
+	if ( size == 0 ) {
+		return true;
+	}
 	return gzwrite( f, data, (unsigned)size ) == (int)size;
 }
 
 template<typename T>
 static bool Nav_WriteValue( gzFile f, const T &v ) {
-	/**
-	*	Write a typed POD value.
-	**/
 	return Nav_Write( f, &v, sizeof( T ) );
+}
+
+static void Nav_BufferWrite( std::vector<uint8_t> &out, const void *data, const size_t size ) {
+	if ( !data || size == 0 ) {
+		return;
+	}
+
+	const size_t oldSize = out.size();
+	out.resize( oldSize + size );
+	memcpy( out.data() + oldSize, data, size );
+}
+
+template<typename T>
+static void Nav_BufferWriteValue( std::vector<uint8_t> &out, const T &v ) {
+	Nav_BufferWrite( out, &v, sizeof( T ) );
+}
+
+static void Nav_BufferWriteTilePayload( std::vector<uint8_t> &out, const nav_tile_t *tile, const int32_t cellsPerTile ) {
+	if ( !tile ) {
+		const int32_t tileX = 0;
+		const int32_t tileY = 0;
+		const int32_t populated = 0;
+		Nav_BufferWriteValue( out, tileX );
+		Nav_BufferWriteValue( out, tileY );
+		Nav_BufferWriteValue( out, populated );
+		return;
+	}
+
+	Nav_BufferWriteValue( out, tile->tile_x );
+	Nav_BufferWriteValue( out, tile->tile_y );
+
+	int32_t populated = 0;
+	for ( int32_t c = 0; c < cellsPerTile; c++ ) {
+		if ( tile->cells && tile->cells[ c ].num_layers > 0 && tile->cells[ c ].layers ) {
+			populated++;
+		}
+	}
+	Nav_BufferWriteValue( out, populated );
+
+	if ( populated <= 0 || !tile->cells ) {
+		return;
+	}
+
+	for ( int32_t c = 0; c < cellsPerTile; c++ ) {
+		const nav_xy_cell_t &cell = tile->cells[ c ];
+		if ( cell.num_layers <= 0 || !cell.layers ) {
+			continue;
+		}
+
+		Nav_BufferWriteValue( out, c );
+		Nav_BufferWriteValue( out, cell.num_layers );
+		Nav_BufferWrite( out, cell.layers, sizeof( nav_layer_t ) * (size_t)cell.num_layers );
+	}
+}
+
+static bool Nav_WriteChunk( gzFile f, const uint32_t chunkId, const std::vector<uint8_t> &payload ) {
+	const uint32_t payloadSize = (uint32_t)payload.size();
+	const uint32_t payloadCrc = payloadSize > 0
+		? Nav_Hash32( payload.data(), payload.size() )
+		: 0;
+
+	if ( !Nav_WriteValue( f, chunkId ) ||
+		!Nav_WriteValue( f, payloadSize ) ||
+		!Nav_WriteValue( f, payloadCrc ) ) {
+		return false;
+	}
+
+	return Nav_Write( f, payload.data(), payloadSize );
+}
+
+static uint32_t Nav_CalcMapHash( void ) {
+	if ( !level.mapname[ 0 ] ) {
+		return 0;
+	}
+	return Nav_Hash32( level.mapname, strlen( level.mapname ) );
+}
+
+static uint32_t Nav_CalcParamsHash( const nav_mesh_t *mesh ) {
+	if ( !mesh ) {
+		return 0;
+	}
+
+	struct nav_params_hash_data_t {
+		double cell_size_xy;
+		double z_quant;
+		int32_t tile_size;
+		double max_step;
+		double max_slope_deg;
+		Vector3 agent_mins;
+		Vector3 agent_maxs;
+		int32_t num_leafs;
+		int32_t num_inline_models;
+		int32_t num_world_tiles;
+	};
+
+	const nav_params_hash_data_t data = {
+		mesh->cell_size_xy,
+		mesh->z_quant,
+		mesh->tile_size,
+		mesh->max_step,
+		mesh->max_slope_deg,
+		mesh->agent_mins,
+		mesh->agent_maxs,
+		mesh->num_leafs,
+		mesh->num_inline_models,
+		(int32_t)mesh->world_tiles.size()
+	};
+
+	return Nav_Hash32( &data, sizeof( data ) );
 }
 
 /**
@@ -51,9 +183,6 @@ static bool Nav_WriteValue( gzFile f, const T &v ) {
 *	@return	True on success, false on failure.
 **/
 bool SVG_Nav_SaveVoxelMesh( const char *filename ) {
-	/**
-	*	Sanity checks: require filename and an active nav mesh.
-	**/
 	if ( !filename || !filename[ 0 ] ) {
 		return false;
 	}
@@ -61,14 +190,7 @@ bool SVG_Nav_SaveVoxelMesh( const char *filename ) {
 		return false;
 	}
 
-	/**
-	*	Build full file path for the nav cache.
-	**/
 	const std::string filePath = BASEGAME "/maps/nav/" + std::string( filename );
-
-	/**
-	*	Open output file (gzip if zlib enabled).
-	**/
 	gzFile f = gzopen( filePath.c_str(), "wb" );
 	if ( !f ) {
 		gi.dprintf( "%s: failed to open '%s'\n", __func__, filePath.c_str() );
@@ -76,129 +198,82 @@ bool SVG_Nav_SaveVoxelMesh( const char *filename ) {
 	}
 
 	gzbuffer( f, 65536 );
-
-	// Snapshot the mesh pointer for readability.
 	const nav_mesh_t *mesh = g_nav_mesh.get();
+	const int32_t cellsPerTile = mesh->tile_size * mesh->tile_size;
 
-	/**
-	*	Write file header (magic + version).
-	**/
+	const uint32_t chunkCount = 4;
 	if ( !Nav_WriteValue( f, NAV_MESH_SAVE_MAGIC ) ||
-		!Nav_WriteValue( f, NAV_MESH_SAVE_VERSION ) ) {
+		!Nav_WriteValue( f, NAV_MESH_SAVE_VERSION ) ||
+		!Nav_WriteValue( f, NAV_MESH_SAVE_ENDIAN_MARKER ) ||
+		!Nav_WriteValue( f, Nav_CalcMapHash() ) ||
+		!Nav_WriteValue( f, Nav_CalcParamsHash( mesh ) ) ||
+		!Nav_WriteValue( f, chunkCount ) ) {
 		gzclose( f );
 		return false;
 	}
 
-	/**
-	*	Write generation parameters needed to interpret mesh data.
-	**/
-	Nav_WriteValue( f, mesh->cell_size_xy );
-	Nav_WriteValue( f, mesh->z_quant );
-	Nav_WriteValue( f, mesh->tile_size );
-	Nav_WriteValue( f, mesh->max_step );
-	Nav_WriteValue( f, mesh->max_slope_deg );
-	Nav_WriteValue( f, mesh->agent_mins );
-	Nav_WriteValue( f, mesh->agent_maxs );
-
-	/**
-	*	Write mesh counts.
-	**/
-	Nav_WriteValue( f, mesh->num_leafs );
-	Nav_WriteValue( f, mesh->num_inline_models );
-
-	const int32_t cellsPerTile = mesh->tile_size * mesh->tile_size;
-
-	/**
-	*	Write world mesh (per BSP leaf).
-	**/
-	for ( int32_t i = 0; i < mesh->num_leafs; i++ ) {
-		const nav_leaf_data_t *leaf = &mesh->leaf_data[ i ];
-		// Write leaf header.
-		Nav_WriteValue( f, leaf->leaf_index );
-		Nav_WriteValue( f, leaf->num_tiles );
-
-		for ( int32_t t = 0; t < leaf->num_tiles; t++ ) {
-			const int32_t tileId = leaf->tile_ids ? leaf->tile_ids[ t ] : -1;
-			if ( tileId < 0 || tileId >= (int32_t)mesh->world_tiles.size() ) {
-				// Corrupt mesh; write a dummy empty tile to keep the stream aligned.
-				nav_tile_t dummy = {};
-				Nav_WriteValue( f, dummy.tile_x );
-				Nav_WriteValue( f, dummy.tile_y );
-				Nav_WriteValue( f, (int32_t)0 );
-				continue;
-			}
-			const nav_tile_t *tile = &mesh->world_tiles[ tileId ];
-			// Write tile coordinates.
-			Nav_WriteValue( f, tile->tile_x );
-			Nav_WriteValue( f, tile->tile_y );
-
-			/**
-			*	Count populated cells so we only serialize active cells.
-			**/
-			int32_t populated = 0;
-			for ( int32_t c = 0; c < cellsPerTile; c++ ) {
-				if ( tile->cells[ c ].num_layers > 0 && tile->cells[ c ].layers ) {
-					populated++;
-				}
-			}
-			// Write populated cell count.
-			Nav_WriteValue( f, populated );
-
-			for ( int32_t c = 0; c < cellsPerTile; c++ ) {
-				const nav_xy_cell_t &cell = tile->cells[ c ];
-				if ( cell.num_layers <= 0 || !cell.layers ) {
-					continue;
-				}
-
-				// Write cell index + layer count.
-				Nav_WriteValue( f, c );
-				Nav_WriteValue( f, cell.num_layers );
-				// Write raw layer array.
-				Nav_Write( f, cell.layers, sizeof( nav_layer_t ) * (size_t)cell.num_layers );
-			}
-		}
+	std::vector<uint8_t> paramChunk = {};
+	Nav_BufferWriteValue( paramChunk, mesh->cell_size_xy );
+	Nav_BufferWriteValue( paramChunk, mesh->z_quant );
+	Nav_BufferWriteValue( paramChunk, mesh->tile_size );
+	Nav_BufferWriteValue( paramChunk, mesh->max_step );
+	Nav_BufferWriteValue( paramChunk, mesh->max_slope_deg );
+	Nav_BufferWriteValue( paramChunk, mesh->agent_mins );
+	Nav_BufferWriteValue( paramChunk, mesh->agent_maxs );
+	Nav_BufferWriteValue( paramChunk, mesh->num_leafs );
+	Nav_BufferWriteValue( paramChunk, mesh->num_inline_models );
+	const int32_t numWorldTiles = (int32_t)mesh->world_tiles.size();
+	Nav_BufferWriteValue( paramChunk, numWorldTiles );
+	if ( !Nav_WriteChunk( f, NAV_CHUNK_PARAM, paramChunk ) ) {
+		gzclose( f );
+		return false;
 	}
 
-	/**
-	*	Write inline model mesh (model-local space).
-	**/
+	std::vector<uint8_t> worldTilesChunk = {};
+	Nav_BufferWriteValue( worldTilesChunk, numWorldTiles );
+	for ( int32_t i = 0; i < numWorldTiles; i++ ) {
+		const nav_tile_t *tile = &mesh->world_tiles[ i ];
+		Nav_BufferWriteTilePayload( worldTilesChunk, tile, cellsPerTile );
+	}
+	if ( !Nav_WriteChunk( f, NAV_CHUNK_WORLD_TILES, worldTilesChunk ) ) {
+		gzclose( f );
+		return false;
+	}
+
+	std::vector<uint8_t> leafMapChunk = {};
+	Nav_BufferWriteValue( leafMapChunk, mesh->num_leafs );
+	for ( int32_t i = 0; i < mesh->num_leafs; i++ ) {
+		const nav_leaf_data_t *leaf = &mesh->leaf_data[ i ];
+		Nav_BufferWriteValue( leafMapChunk, leaf->leaf_index );
+		Nav_BufferWriteValue( leafMapChunk, leaf->num_tiles );
+		for ( int32_t t = 0; t < leaf->num_tiles; t++ ) {
+			int32_t tileId = -1;
+			if ( leaf->tile_ids ) {
+				tileId = leaf->tile_ids[ t ];
+			}
+			Nav_BufferWriteValue( leafMapChunk, tileId );
+		}
+	}
+	if ( !Nav_WriteChunk( f, NAV_CHUNK_LEAF_MAP, leafMapChunk ) ) {
+		gzclose( f );
+		return false;
+	}
+
+	std::vector<uint8_t> inlineChunk = {};
+	Nav_BufferWriteValue( inlineChunk, mesh->num_inline_models );
 	for ( int32_t i = 0; i < mesh->num_inline_models; i++ ) {
 		const nav_inline_model_data_t *model = &mesh->inline_model_data[ i ];
-		// Write model header.
-		Nav_WriteValue( f, model->model_index );
-		Nav_WriteValue( f, model->num_tiles );
+		Nav_BufferWriteValue( inlineChunk, model->model_index );
+		Nav_BufferWriteValue( inlineChunk, model->num_tiles );
 
 		for ( int32_t t = 0; t < model->num_tiles; t++ ) {
-			const nav_tile_t *tile = &model->tiles[ t ];
-			// Write tile coordinates.
-			Nav_WriteValue( f, tile->tile_x );
-			Nav_WriteValue( f, tile->tile_y );
-
-			/**
-			*	Count populated cells so we only serialize active cells.
-			**/
-			int32_t populated = 0;
-			for ( int32_t c = 0; c < cellsPerTile; c++ ) {
-				if ( tile->cells[ c ].num_layers > 0 && tile->cells[ c ].layers ) {
-					populated++;
-				}
-			}
-			// Write populated cell count.
-			Nav_WriteValue( f, populated );
-
-			for ( int32_t c = 0; c < cellsPerTile; c++ ) {
-				const nav_xy_cell_t &cell = tile->cells[ c ];
-				if ( cell.num_layers <= 0 || !cell.layers ) {
-					continue;
-				}
-
-				// Write cell index + layer count.
-				Nav_WriteValue( f, c );
-				Nav_WriteValue( f, cell.num_layers );
-				// Write raw layer array.
-				Nav_Write( f, cell.layers, sizeof( nav_layer_t ) * (size_t)cell.num_layers );
-			}
+			const nav_tile_t *tile = model->tiles ? &model->tiles[ t ] : nullptr;
+			Nav_BufferWriteTilePayload( inlineChunk, tile, cellsPerTile );
 		}
+	}
+	if ( !Nav_WriteChunk( f, NAV_CHUNK_INLINE_MODELS, inlineChunk ) ) {
+		gzclose( f );
+		return false;
 	}
 
 	gzclose( f );

--- a/src/baseq2rtxp/svgame/nav/svg_nav_traversal.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_traversal.cpp
@@ -24,6 +24,7 @@
 #include "common/bsp.h"
 #include "common/files.h"
 
+#include <algorithm>
 #include <cmath>
 
 extern cvar_t *nav_max_step;
@@ -37,6 +38,245 @@ extern cvar_t *nav_debug_draw_path;
 **/
 inline bool Nav_PathDiagEnabled( void ) {
 	return nav_debug_draw && nav_debug_draw->integer >= 2;
+}
+
+//! Guards recursion while detour prototype re-enters voxel backend wrappers.
+static bool s_nav_backend_detour_fallback_active = false;
+//! Runtime profile for backend comparison (voxel vs detour-prototype).
+static nav_backend_profile_t s_nav_backend_profile = {};
+
+/**
+*   @brief	Forward declaration for edge-validation helper used by detour string-pull.
+**/
+const bool Nav_CanTraverseStep_ExplicitBBox( const nav_mesh_t *mesh, const Vector3 &startPos, const Vector3 &endPos,
+	const Vector3 &mins, const Vector3 &maxs, const edict_ptr_t *clip_entity, const svg_nav_path_policy_t *policy );
+
+/**
+*    @brief    Return the currently selected traversal backend label.
+**/
+const char *SVG_Nav_GetPathBackendName( void ) {
+	if ( nav_path_backend && nav_path_backend->integer == 1 ) {
+		return "detour-prototype";
+	}
+	return "voxel";
+}
+
+/**
+*    @brief    Check whether traversal API calls should dispatch to detour prototype pathing.
+**/
+static bool Nav_ShouldUseDetourBackend( void ) {
+	return nav_path_backend
+		&& nav_path_backend->integer == 1
+		&& !s_nav_backend_detour_fallback_active;
+}
+
+/**
+*    @brief    Lightweight scope guard to disable backend recursion while delegating.
+**/
+struct nav_detour_reentry_guard_t {
+	nav_detour_reentry_guard_t() {
+		s_nav_backend_detour_fallback_active = true;
+	}
+	~nav_detour_reentry_guard_t() {
+		s_nav_backend_detour_fallback_active = false;
+	}
+};
+
+/**
+*    @brief    Record backend runtime statistics for detour-prototype queries.
+**/
+static void Nav_BackendProfile_RecordDetourQuery( const bool success, const uint64_t elapsedMs, const int32_t inputPoints, const int32_t outputPoints ) {
+	s_nav_backend_profile.detour_queries++;
+	if ( success ) {
+		s_nav_backend_profile.detour_success++;
+	} else {
+		s_nav_backend_profile.detour_failed++;
+	}
+	s_nav_backend_profile.detour_total_ms += elapsedMs;
+	s_nav_backend_profile.detour_max_ms = std::max( s_nav_backend_profile.detour_max_ms, elapsedMs );
+	s_nav_backend_profile.detour_points_before += std::max( 0, inputPoints );
+	s_nav_backend_profile.detour_points_after += std::max( 0, outputPoints );
+}
+
+/**
+*    @brief    Snapshot backend runtime profile.
+**/
+void SVG_Nav_GetBackendProfile( nav_backend_profile_t *outProfile ) {
+	if ( !outProfile ) {
+		return;
+	}
+	*outProfile = s_nav_backend_profile;
+}
+
+/**
+*    @brief    Reset backend runtime profile counters.
+**/
+void SVG_Nav_ResetBackendProfile( void ) {
+	s_nav_backend_profile = {};
+}
+
+/**
+*    @brief    Apply a detour-style aggressive string-pull over voxel waypoints.
+**/
+static void Nav_DetourPrototype_StringPull( const nav_mesh_t *mesh, const Vector3 &agent_mins, const Vector3 &agent_maxs,
+	const svg_nav_path_policy_t *policy, const std::vector<Vector3> &inputPoints, std::vector<Vector3> *outPoints ) {
+	if ( !outPoints ) {
+		return;
+	}
+	outPoints->clear();
+
+	if ( inputPoints.empty() ) {
+		return;
+	}
+	if ( inputPoints.size() <= 2 || !mesh ) {
+		*outPoints = inputPoints;
+		return;
+	}
+
+	// Remove tiny duplicate hops first to avoid degenerate edges in string-pull.
+	std::vector<Vector3> dedup;
+	dedup.reserve( inputPoints.size() );
+	for ( const Vector3 &p : inputPoints ) {
+		if ( dedup.empty() ) {
+			dedup.push_back( p );
+			continue;
+		}
+		const Vector3 d = QM_Vector3Subtract( p, dedup.back() );
+		if ( QM_Vector3LengthDP( d ) > 0.1 ) {
+			dedup.push_back( p );
+		}
+	}
+
+	if ( dedup.size() <= 2 ) {
+		*outPoints = dedup;
+		return;
+	}
+
+	outPoints->reserve( dedup.size() );
+	int32_t anchor = 0;
+	outPoints->push_back( dedup[ 0 ] );
+	const int32_t count = ( int32_t )dedup.size();
+
+	while ( anchor < ( count - 1 ) ) {
+		int32_t best = anchor + 1;
+		for ( int32_t probe = count - 1; probe > anchor + 1; --probe ) {
+			if ( Nav_CanTraverseStep_ExplicitBBox( mesh, dedup[ anchor ], dedup[ probe ], agent_mins, agent_maxs, nullptr, policy ) ) {
+				best = probe;
+				break;
+			}
+		}
+
+		outPoints->push_back( dedup[ best ] );
+		anchor = best;
+	}
+}
+
+/**
+*    @brief    Post-process a generated path using detour-prototype straight-path extraction.
+**/
+static void Nav_DetourPrototype_PostProcessPath( const nav_mesh_t *mesh, const Vector3 &agent_mins, const Vector3 &agent_maxs,
+	const svg_nav_path_policy_t *policy, nav_traversal_path_t *io_path, int32_t *outInputPoints, int32_t *outOutputPoints ) {
+	if ( outInputPoints ) {
+		*outInputPoints = 0;
+	}
+	if ( outOutputPoints ) {
+		*outOutputPoints = 0;
+	}
+
+	if ( !io_path || !io_path->points || io_path->num_points <= 0 ) {
+		return;
+	}
+
+	std::vector<Vector3> originalPoints;
+	originalPoints.assign( io_path->points, io_path->points + io_path->num_points );
+	if ( outInputPoints ) {
+		*outInputPoints = ( int32_t )originalPoints.size();
+	}
+
+	std::vector<Vector3> simplifiedPoints;
+	Nav_DetourPrototype_StringPull( mesh, agent_mins, agent_maxs, policy, originalPoints, &simplifiedPoints );
+	if ( simplifiedPoints.empty() ) {
+		simplifiedPoints = originalPoints;
+	}
+	if ( outOutputPoints ) {
+		*outOutputPoints = ( int32_t )simplifiedPoints.size();
+	}
+
+	if ( simplifiedPoints.size() == originalPoints.size() ) {
+		return;
+	}
+
+	Vector3 *newPoints = ( Vector3 * )gi.TagMallocz( sizeof( Vector3 ) * simplifiedPoints.size(), TAG_SVGAME_LEVEL );
+	memcpy( newPoints, simplifiedPoints.data(), sizeof( Vector3 ) * simplifiedPoints.size() );
+
+	gi.TagFree( io_path->points );
+	io_path->points = newPoints;
+	io_path->num_points = ( int32_t )simplifiedPoints.size();
+}
+
+static bool Nav_DetourFallback_GenerateTraversalPathForOrigin( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path ) {
+	const uint64_t startMs = gi.GetRealSystemTime();
+	nav_detour_reentry_guard_t reentryGuard = {};
+	const bool ok = SVG_Nav_GenerateTraversalPathForOrigin( start_origin, goal_origin, out_path );
+	int32_t inputPoints = 0;
+	int32_t outputPoints = 0;
+	if ( ok ) {
+		const nav_mesh_t *mesh = g_nav_mesh.get();
+		const Vector3 mins = mesh ? mesh->agent_mins : Vector3{};
+		const Vector3 maxs = mesh ? mesh->agent_maxs : Vector3{};
+		Nav_DetourPrototype_PostProcessPath( mesh, mins, maxs, nullptr,
+			out_path, &inputPoints, &outputPoints );
+	}
+	Nav_BackendProfile_RecordDetourQuery( ok, gi.GetRealSystemTime() - startMs, inputPoints, outputPoints );
+	return ok;
+}
+
+static bool Nav_DetourFallback_GenerateTraversalPathForOriginEx( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path,
+	const bool enable_goal_z_layer_blend, const double blend_start_dist, const double blend_full_dist ) {
+	const uint64_t startMs = gi.GetRealSystemTime();
+	nav_detour_reentry_guard_t reentryGuard = {};
+	const bool ok = SVG_Nav_GenerateTraversalPathForOriginEx( start_origin, goal_origin, out_path, enable_goal_z_layer_blend, blend_start_dist, blend_full_dist );
+	int32_t inputPoints = 0;
+	int32_t outputPoints = 0;
+	if ( ok ) {
+		const nav_mesh_t *mesh = g_nav_mesh.get();
+		const Vector3 mins = mesh ? mesh->agent_mins : Vector3{};
+		const Vector3 maxs = mesh ? mesh->agent_maxs : Vector3{};
+		Nav_DetourPrototype_PostProcessPath( mesh, mins, maxs, nullptr,
+			out_path, &inputPoints, &outputPoints );
+	}
+	Nav_BackendProfile_RecordDetourQuery( ok, gi.GetRealSystemTime() - startMs, inputPoints, outputPoints );
+	return ok;
+}
+
+static bool Nav_DetourFallback_GenerateTraversalPathForOrigin_WithAgentBBox( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path,
+	const Vector3 &agent_mins, const Vector3 &agent_maxs, const svg_nav_path_policy_t *policy ) {
+	const uint64_t startMs = gi.GetRealSystemTime();
+	nav_detour_reentry_guard_t reentryGuard = {};
+	const bool ok = SVG_Nav_GenerateTraversalPathForOrigin_WithAgentBBox( start_origin, goal_origin, out_path, agent_mins, agent_maxs, policy );
+	int32_t inputPoints = 0;
+	int32_t outputPoints = 0;
+	if ( ok ) {
+		Nav_DetourPrototype_PostProcessPath( g_nav_mesh.get(), agent_mins, agent_maxs, policy, out_path, &inputPoints, &outputPoints );
+	}
+	Nav_BackendProfile_RecordDetourQuery( ok, gi.GetRealSystemTime() - startMs, inputPoints, outputPoints );
+	return ok;
+}
+
+static bool Nav_DetourFallback_GenerateTraversalPathForOriginEx_WithAgentBBox( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path,
+	const Vector3 &agent_mins, const Vector3 &agent_maxs, const svg_nav_path_policy_t *policy, const bool enable_goal_z_layer_blend, const double blend_start_dist,
+	const double blend_full_dist, const struct svg_nav_path_process_t *pathProcess ) {
+	const uint64_t startMs = gi.GetRealSystemTime();
+	nav_detour_reentry_guard_t reentryGuard = {};
+	const bool ok = SVG_Nav_GenerateTraversalPathForOriginEx_WithAgentBBox( start_origin, goal_origin, out_path, agent_mins, agent_maxs, policy,
+		enable_goal_z_layer_blend, blend_start_dist, blend_full_dist, pathProcess );
+	int32_t inputPoints = 0;
+	int32_t outputPoints = 0;
+	if ( ok ) {
+		Nav_DetourPrototype_PostProcessPath( g_nav_mesh.get(), agent_mins, agent_maxs, policy, out_path, &inputPoints, &outputPoints );
+	}
+	Nav_BackendProfile_RecordDetourQuery( ok, gi.GetRealSystemTime() - startMs, inputPoints, outputPoints );
+	return ok;
 }
 
 static void Nav_Debug_PrintNodeRef( const char *label, const nav_node_ref_t &n ) {
@@ -303,17 +543,23 @@ static bool Nav_AStarSearch( const nav_mesh_t *mesh, const nav_node_ref_t &start
 	gi.dprintf( "[WARNING][NavPath][A*] Pathfinding failed: No path found from (%.1f,%.1f,%.1f) to (%.1f,%.1f,%.1f)\n",
 		start_node.position.x, start_node.position.y, start_node.position.z,
 		goal_node.position.x, goal_node.position.y, goal_node.position.z );
-	gi.dprintf( "[WARNING][NavPath][A*] Search stats: explored=%d nodes, max_nodes=%d, open_list_empty=%s\n",
+	gi.dprintf( "[WARNING][NavPath][A*] Search stats: explored=%d nodes, max_nodes=%d, open_set_empty=%s\n",
 		( int32_t )state.nodes.size(),
 		state.max_nodes,
-		state.open_list.empty() ? "true" : "false" );
+		state.open_heap.empty() ? "true" : "false" );
 
 	/**
 	*    Emit detailed diagnostics only when explicitly requested.
 	**/
 	if ( navDiag ) {
-		gi.dprintf( "[DEBUG][NavPath][Diag] A* summary: neighbor_tries=%d, no_node=%d, edge_reject=%d, tile_filter_reject=%d, stagnation=%d\n",
-			state.neighbor_try_count, state.no_node_count, state.edge_reject_count, state.tile_filter_reject_count, state.stagnation_count );
+		gi.dprintf( "[DEBUG][NavPath][Diag] A* summary: neighbor_tries=%d, no_node=%d, edge_reject=%d, tile_filter_reject=%d, edge_cache_hits=%d, edge_cache_store=%d, stagnation=%d\n",
+			state.neighbor_try_count,
+			state.no_node_count,
+			state.edge_reject_count,
+			state.tile_filter_reject_count,
+			state.edge_cache_hit_count,
+			state.edge_cache_store_count,
+			state.stagnation_count );
 		gi.dprintf( "[DEBUG][NavPath][Diag] A* inputs: max_step=%.1f max_drop=%.1f cell_size_xy=%.1f z_quant=%.1f\n",
 			nav_max_step ? nav_max_step->value : -1.0f,
 			nav_drop_cap ? nav_drop_cap->value : -1.0f,
@@ -349,8 +595,8 @@ static bool Nav_AStarSearch( const nav_mesh_t *mesh, const nav_node_ref_t &start
 		gi.dprintf( "[WARNING][NavPath][A*] Failure reason: Search failed due to excessive stagnation after %d iterations.\n", state.stagnation_count );
 	} else if ( ( int32_t )state.nodes.size() >= state.max_nodes ) {
 		gi.dprintf( "[WARNING][NavPath][A*] Failure reason: Search node limit reached (%d nodes). The navmesh may be too large or the goal is very far.\n", state.max_nodes );
-	} else if ( state.open_list.empty() ) {
-		gi.dprintf( "[WARNING][NavPath][A*] Failure reason: Open list exhausted. This typically means:\n" );
+	} else if ( state.open_heap.empty() ) {
+		gi.dprintf( "[WARNING][NavPath][A*] Failure reason: Open set exhausted. This typically means:\n" );
 		gi.dprintf( "[WARNING][NavPath][A*]   1. No navmesh connectivity exists between start and goal Z-levels\n" );
 		gi.dprintf( "[WARNING][NavPath][A*]   2. All potential paths are blocked by obstacles\n" );
 		gi.dprintf( "[WARNING][NavPath][A*]   3. Edge validation (Nav_CanTraverseStep) rejected all connections\n" );
@@ -390,6 +636,10 @@ static bool Nav_AStarSearch( const nav_mesh_t *mesh, const nav_node_ref_t &start
 *   @return True if a path was found, false otherwise.
 **/
 const bool SVG_Nav_GenerateTraversalPathForOrigin( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path ) {
+	if ( Nav_ShouldUseDetourBackend() ) {
+		return Nav_DetourFallback_GenerateTraversalPathForOrigin( start_origin, goal_origin, out_path );
+	}
+
 	if ( !out_path ) {
 		return false;
 	}
@@ -485,6 +735,10 @@ const bool SVG_Nav_GenerateTraversalPathForOrigin( const Vector3 &start_origin, 
 
 const bool SVG_Nav_GenerateTraversalPathForOriginEx( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path,
 	const bool enable_goal_z_layer_blend, const double blend_start_dist, const double blend_full_dist ) {
+	if ( Nav_ShouldUseDetourBackend() ) {
+		return Nav_DetourFallback_GenerateTraversalPathForOriginEx( start_origin, goal_origin, out_path, enable_goal_z_layer_blend, blend_start_dist, blend_full_dist );
+	}
+
 	if ( !out_path ) {
 		return false;
 	}
@@ -589,6 +843,10 @@ const bool SVG_Nav_GenerateTraversalPathForOriginEx( const Vector3 &start_origin
 
 const bool SVG_Nav_GenerateTraversalPathForOrigin_WithAgentBBox( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path,
 	const Vector3 &agent_mins, const Vector3 &agent_maxs, const svg_nav_path_policy_t *policy ) {
+	if ( Nav_ShouldUseDetourBackend() ) {
+		return Nav_DetourFallback_GenerateTraversalPathForOrigin_WithAgentBBox( start_origin, goal_origin, out_path, agent_mins, agent_maxs, policy );
+	}
+
 	if ( !out_path ) {
 		return false;
 	}
@@ -641,6 +899,11 @@ const bool SVG_Nav_GenerateTraversalPathForOrigin_WithAgentBBox( const Vector3 &
 const bool SVG_Nav_GenerateTraversalPathForOriginEx_WithAgentBBox( const Vector3 &start_origin, const Vector3 &goal_origin, nav_traversal_path_t *out_path,
 	const Vector3 &agent_mins, const Vector3 &agent_maxs, const svg_nav_path_policy_t *policy, const bool enable_goal_z_layer_blend, const double blend_start_dist, const double blend_full_dist,
 	const struct svg_nav_path_process_t *pathProcess ) {
+	if ( Nav_ShouldUseDetourBackend() ) {
+		return Nav_DetourFallback_GenerateTraversalPathForOriginEx_WithAgentBBox( start_origin, goal_origin, out_path, agent_mins, agent_maxs, policy,
+			enable_goal_z_layer_blend, blend_start_dist, blend_full_dist, pathProcess );
+	}
+
 	if ( !out_path ) {
 		return false;
 	}

--- a/src/baseq2rtxp/svgame/nav/svg_nav_traversal.h
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_traversal.h
@@ -31,6 +31,15 @@ const bool SVG_Nav_GenerateTraversalPathForOrigin( const Vector3 &start_origin, 
  **/
 const Vector3 SVG_Nav_ConvertFeetToCenter( const nav_mesh_t *mesh, const Vector3 &feet_origin, const Vector3 *agent_mins = nullptr, const Vector3 *agent_maxs = nullptr );
 /**
+ *    @brief    Convert a nav-center position back to caller-facing feet-origin space.
+ *    @param    mesh          Navigation mesh used to derive default agent hull when agent bbox is omitted.
+ *    @param    center_origin World-space nav-center origin.
+ *    @param    agent_mins    Optional agent bbox mins to override mesh defaults.
+ *    @param    agent_maxs    Optional agent bbox maxs to override mesh defaults.
+ *    @return   Feet-origin world position (inverse of SVG_Nav_ConvertFeetToCenter).
+ **/
+const Vector3 SVG_Nav_ConvertCenterToFeet( const nav_mesh_t *mesh, const Vector3 &center_origin, const Vector3 *agent_mins = nullptr, const Vector3 *agent_maxs = nullptr );
+/**
 *	@brief  Generate a traversal path between two origins with optional goal Z-layer blending.
 *	@param  start_origin             World-space start origin.
 *	@param  goal_origin              World-space goal origin.

--- a/src/baseq2rtxp/svgame/nav/svg_nav_traversal_async.cpp
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_traversal_async.cpp
@@ -29,6 +29,7 @@ extern cvar_t *nav_cost_turn_weight;
 extern cvar_t *nav_cost_slope_weight;
 extern cvar_t *nav_cost_drop_weight;
 extern cvar_t *nav_cost_min_cost_per_unit;
+extern cvar_t *nav_multi_agent_mode;
 
 inline bool Nav_PathDiagEnabled( void );
 
@@ -101,6 +102,56 @@ static inline double Nav_AStar_Heuristic( const Vector3 &a, const Vector3 &b ) {
 	return sqrtf( ( delta[ 0 ] * delta[ 0 ] ) + ( delta[ 1 ] * delta[ 1 ] ) + ( delta[ 2 ] * delta[ 2 ] ) );
 }
 
+static inline bool Nav_NodeKeyLess( const nav_node_key_t &a, const nav_node_key_t &b ) {
+	if ( a.leaf_index != b.leaf_index ) {
+		return a.leaf_index < b.leaf_index;
+	}
+	if ( a.tile_index != b.tile_index ) {
+		return a.tile_index < b.tile_index;
+	}
+	if ( a.cell_index != b.cell_index ) {
+		return a.cell_index < b.cell_index;
+	}
+	return a.layer_index < b.layer_index;
+}
+
+static inline void Nav_MixEdgeHash32( uint64_t *hash, const uint32_t value ) {
+	*hash ^= (uint64_t)value;
+	*hash *= 1099511628211ull;
+}
+
+static uint64_t Nav_BuildUndirectedEdgeCacheKey( const nav_node_key_t &a, const nav_node_key_t &b ) {
+	const nav_node_key_t *first = &a;
+	const nav_node_key_t *second = &b;
+	if ( Nav_NodeKeyLess( b, a ) ) {
+		first = &b;
+		second = &a;
+	}
+
+	uint64_t hash = 1469598103934665603ull;
+	Nav_MixEdgeHash32( &hash, (uint32_t)first->leaf_index );
+	Nav_MixEdgeHash32( &hash, (uint32_t)first->tile_index );
+	Nav_MixEdgeHash32( &hash, (uint32_t)first->cell_index );
+	Nav_MixEdgeHash32( &hash, (uint32_t)first->layer_index );
+	Nav_MixEdgeHash32( &hash, (uint32_t)second->leaf_index );
+	Nav_MixEdgeHash32( &hash, (uint32_t)second->tile_index );
+	Nav_MixEdgeHash32( &hash, (uint32_t)second->cell_index );
+	Nav_MixEdgeHash32( &hash, (uint32_t)second->layer_index );
+	return hash;
+}
+
+static inline void Nav_AStar_PushOpen( nav_a_star_state_t *state, const int32_t node_index, const double f_cost ) {
+	if ( !state || node_index < 0 ) {
+		return;
+	}
+
+	nav_a_star_open_item_t item = {};
+	item.f_cost = f_cost;
+	item.node_index = node_index;
+	item.sequence = state->open_sequence++;
+	state->open_heap.push( item );
+}
+
 static void Nav_AStar_ExpandNeighbors( nav_a_star_state_t *state, int32_t current_index ) {
 	const nav_mesh_t *mesh = state->mesh;
 	if ( !mesh ) {
@@ -126,13 +177,7 @@ static void Nav_AStar_ExpandNeighbors( nav_a_star_state_t *state, int32_t curren
 		**/
 		if ( tileRouteFilter && !tileRouteFilter->empty() ) {
 			const nav_tile_cluster_key_t nk = SVG_Nav_GetTileKeyForPosition( mesh, neighbor_origin );
-			bool allowed = false;
-			for ( const nav_tile_cluster_key_t &k : *tileRouteFilter ) {
-				if ( k == nk ) {
-					allowed = true;
-					break;
-				}
-			}
+			const bool allowed = state->tile_route_lookup.find( nk ) != state->tile_route_lookup.end();
 			if ( !allowed ) {
           // Neighbor rejected due to tile-route filter.
 			state->tile_filter_reject_count++;
@@ -155,6 +200,26 @@ static void Nav_AStar_ExpandNeighbors( nav_a_star_state_t *state, int32_t curren
 			continue;
 		}
 
+		const nav_layer_t *neighborLayer = nullptr;
+		if ( neighbor_node.key.tile_index >= 0 && neighbor_node.key.tile_index < ( int32_t )mesh->world_tiles.size() ) {
+			const nav_tile_t *tile = &mesh->world_tiles[ neighbor_node.key.tile_index ];
+			const int32_t cellsPerTile = mesh->tile_size * mesh->tile_size;
+			if ( neighbor_node.key.cell_index >= 0 && neighbor_node.key.cell_index < cellsPerTile ) {
+				const nav_xy_cell_t *cell = &tile->cells[ neighbor_node.key.cell_index ];
+				if ( neighbor_node.key.layer_index >= 0 && neighbor_node.key.layer_index < cell->num_layers ) {
+					neighborLayer = &cell->layers[ neighbor_node.key.layer_index ];
+				}
+			}
+		}
+
+		// Multi-agent clearance pruning: if we queried with a taller agent, require extra headroom.
+		if ( state->clearance_prune_enabled && neighborLayer ) {
+			if ( neighborLayer->clearance < state->required_extra_clearance_quants ) {
+				state->edge_reject_count++;
+				continue;
+			}
+		}
+
 		const double neighbor_drop = current.node.position[ 2 ] - neighbor_node.position[ 2 ];
       if ( policy && neighbor_drop > 0.0 && neighbor_drop > policy->drop_cap ) {
 			// Neighbor rejected due to drop cap.
@@ -168,8 +233,24 @@ static void Nav_AStar_ExpandNeighbors( nav_a_star_state_t *state, int32_t curren
 		/**
 		*    The PMove-derived step test covers slopes, hills, and stairs while respecting both
 		*    agent hulls and slope/drop constraints.
+		*
+		*    Cache successful edge traversals per search so repeated corridor expansion avoids
+		*    re-running identical trace sequences.
 		**/
-      if ( !Nav_CanTraverseStep_ExplicitBBox( mesh, current.node.position, neighbor_node.position, agent_mins, agent_maxs, nullptr, policy ) ) {
+		const uint64_t edgeCacheKey = Nav_BuildUndirectedEdgeCacheKey( current.node.key, neighbor_node.key );
+		bool edgeTraversable = false;
+		if ( state->successful_edge_cache.find( edgeCacheKey ) != state->successful_edge_cache.end() ) {
+			edgeTraversable = true;
+			state->edge_cache_hit_count++;
+		} else {
+			edgeTraversable = Nav_CanTraverseStep_ExplicitBBox( mesh, current.node.position, neighbor_node.position, agent_mins, agent_maxs, nullptr, policy );
+			if ( edgeTraversable ) {
+				state->successful_edge_cache.insert( edgeCacheKey );
+				state->edge_cache_store_count++;
+			}
+		}
+
+      if ( !edgeTraversable ) {
 			// Edge validation failed for this neighbor.
 			state->edge_reject_count++;
 			if ( Nav_PathDiagEnabled() ) {
@@ -201,17 +282,6 @@ static void Nav_AStar_ExpandNeighbors( nav_a_star_state_t *state, int32_t curren
 		const double minCostPerUnit = nav_cost_min_cost_per_unit ? nav_cost_min_cost_per_unit->value : 1.0f;
 
 		double extraCost = 0.0;
-
-		const nav_layer_t *neighborLayer = nullptr;
-		if ( neighbor_node.key.leaf_index >= 0 && neighbor_node.key.leaf_index < mesh->num_leafs ) {
-			if ( neighbor_node.key.tile_index >= 0 && neighbor_node.key.tile_index < ( int32_t )mesh->world_tiles.size() ) {
-				const nav_tile_t *tile = &mesh->world_tiles[ neighbor_node.key.tile_index ];
-				const nav_xy_cell_t *cell = &tile->cells[ neighbor_node.key.cell_index ];
-				if ( neighbor_node.key.layer_index >= 0 && neighbor_node.key.layer_index < cell->num_layers ) {
-					neighborLayer = &cell->layers[ neighbor_node.key.layer_index ];
-				}
-			}
-		}
 
 		if ( neighborLayer ) {
 			if ( ( neighborLayer->flags & NAV_FLAG_WATER ) != 0 ) {
@@ -332,7 +402,7 @@ static void Nav_AStar_ExpandNeighbors( nav_a_star_state_t *state, int32_t curren
 
 			state->nodes.push_back( neighbor_search );
 			const int32_t neighbor_index = ( int32_t )state->nodes.size() - 1;
-			state->open_list.push_back( neighbor_index );
+			Nav_AStar_PushOpen( state, neighbor_index, neighbor_search.f_cost );
 			state->node_lookup.emplace( neighbor_node.key, neighbor_index );
 			continue;
 		}
@@ -347,6 +417,7 @@ static void Nav_AStar_ExpandNeighbors( nav_a_star_state_t *state, int32_t curren
 			neighbor_search.g_cost = tentative_g;
 			neighbor_search.f_cost = tentative_g + Nav_AStar_Heuristic( neighbor_node.position, state->goal_node.position );
 			neighbor_search.parent_index = current_index;
+			Nav_AStar_PushOpen( state, neighbor_index, neighbor_search.f_cost );
 		}
 	}
 }
@@ -370,11 +441,31 @@ bool Nav_AStar_Init( nav_a_star_state_t *state, const nav_mesh_t *mesh, const na
 	state->pathProcess = pathProcess;
 	state->max_nodes = NAV_ASTAR_MAX_NODES;
 	state->search_budget_ms = NAV_ASTAR_STEP_BUDGET_MS;
+	state->clearance_prune_enabled = false;
+	state->required_extra_clearance_quants = 0;
+	state->successful_edge_cache.clear();
+	state->successful_edge_cache.reserve( (size_t)state->max_nodes * 2u );
+
+	if ( nav_multi_agent_mode && nav_multi_agent_mode->integer != 0 && mesh->z_quant > 0.0 ) {
+		const double meshHeight = ( double )mesh->agent_maxs.z - ( double )mesh->agent_mins.z;
+		const double requestHeight = ( double )agent_maxs.z - ( double )agent_mins.z;
+		const double extraHeight = requestHeight - meshHeight;
+		if ( extraHeight > 0.0 ) {
+			state->required_extra_clearance_quants = ( uint32_t )std::ceil( extraHeight / mesh->z_quant );
+			state->clearance_prune_enabled = state->required_extra_clearance_quants > 0;
+		}
+	}
 
 	if ( tileRoute && !tileRoute->empty() ) {
 		state->tile_route_storage = *tileRoute;
+		state->tile_route_lookup.clear();
+		state->tile_route_lookup.reserve( state->tile_route_storage.size() * 2 );
+		for ( const nav_tile_cluster_key_t &k : state->tile_route_storage ) {
+			state->tile_route_lookup.insert( k );
+		}
 		state->tileRouteFilter = &state->tile_route_storage;
 	} else {
+		state->tile_route_lookup.clear();
 		state->tileRouteFilter = nullptr;
 	}
 
@@ -387,7 +478,7 @@ bool Nav_AStar_Init( nav_a_star_state_t *state, const nav_mesh_t *mesh, const na
 	};
 
 	state->nodes.push_back( start_search );
-	state->open_list.push_back( 0 );
+	Nav_AStar_PushOpen( state, 0, start_search.f_cost );
 	state->node_lookup.emplace( start_node.key, 0 );
 	state->best_f_cost_seen = start_search.f_cost;
 	state->stagnation_count = 0;
@@ -422,7 +513,23 @@ nav_a_star_status_t Nav_AStar_Step( nav_a_star_state_t *state, int32_t expansion
 	state->step_start_ms = gi.GetRealSystemTime();
 
 	while ( expansions > 0 && state->status == nav_a_star_status_t::Running ) {
-		if ( state->open_list.empty() ) {
+		while ( !state->open_heap.empty() ) {
+			const nav_a_star_open_item_t item = state->open_heap.top();
+			if ( item.node_index < 0 || item.node_index >= ( int32_t )state->nodes.size() ) {
+				state->open_heap.pop();
+				continue;
+			}
+
+			const nav_search_node_t &node = state->nodes[ item.node_index ];
+			if ( node.closed || item.f_cost != node.f_cost ) {
+				state->open_heap.pop();
+				continue;
+			}
+
+			break;
+		}
+
+		if ( state->open_heap.empty() ) {
 			state->status = nav_a_star_status_t::Failed;
 			break;
 		}
@@ -439,14 +546,8 @@ nav_a_star_status_t Nav_AStar_Step( nav_a_star_state_t *state, int32_t expansion
 			break;
 		}
 
-		auto best_it = std::min_element( state->open_list.begin(), state->open_list.end(),
-			[ &state ]( int32_t a, int32_t b ) {
-				return state->nodes[ a ].f_cost < state->nodes[ b ].f_cost;
-			} );
-
-		const int32_t current_index = *best_it;
-		*best_it = state->open_list.back();
-		state->open_list.pop_back();
+		const int32_t current_index = state->open_heap.top().node_index;
+		state->open_heap.pop();
 
 		nav_search_node_t &current = state->nodes[ current_index ];
 		current.closed = true;
@@ -510,12 +611,17 @@ void Nav_AStar_Reset( nav_a_star_state_t *state ) {
 	state->start_node = {};
 	state->goal_node = {};
 	state->nodes.clear();
-	state->open_list.clear();
+	state->open_heap = {};
+	state->open_sequence = 0;
 	state->node_lookup.clear();
 	state->tile_route_storage.clear();
+	state->tile_route_lookup.clear();
+	state->successful_edge_cache.clear();
 	state->tileRouteFilter = nullptr;
 	state->policy = nullptr;
 	state->pathProcess = nullptr;
+	state->clearance_prune_enabled = false;
+	state->required_extra_clearance_quants = 0;
 	state->goal_index = -1;
 	state->best_f_cost_seen = std::numeric_limits<double>::infinity();
 	state->stagnation_count = 0;
@@ -526,5 +632,7 @@ void Nav_AStar_Reset( nav_a_star_state_t *state ) {
 	state->no_node_count = 0;
 	state->tile_filter_reject_count = 0;
 	state->edge_reject_count = 0;
+	state->edge_cache_hit_count = 0;
+	state->edge_cache_store_count = 0;
 	state->step_start_ms = 0;
 }

--- a/src/baseq2rtxp/svgame/nav/svg_nav_traversal_async.h
+++ b/src/baseq2rtxp/svgame/nav/svg_nav_traversal_async.h
@@ -9,7 +9,9 @@
 
 #include <cstdint>
 #include <limits>
+#include <queue>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "svgame/svg_local.h"
@@ -17,6 +19,27 @@
 
 struct svg_nav_path_process_t;
 struct svg_nav_path_policy_t;
+
+/**
+*    @brief    Heap item for lazy-decrease-key A* open set.
+**/
+struct nav_a_star_open_item_t {
+	//! Snapshot f-cost when this item was pushed.
+	double f_cost = 0.0;
+	//! Index into nav_a_star_state_t::nodes.
+	int32_t node_index = -1;
+	//! Monotonic sequence used as a deterministic tie-breaker.
+	uint32_t sequence = 0;
+};
+
+struct nav_a_star_open_item_greater_t {
+	bool operator()( const nav_a_star_open_item_t &a, const nav_a_star_open_item_t &b ) const {
+		if ( a.f_cost == b.f_cost ) {
+			return a.sequence > b.sequence;
+		}
+		return a.f_cost > b.f_cost;
+	}
+};
 
 
 /**
@@ -45,13 +68,18 @@ struct nav_a_star_state_t {
 	nav_node_ref_t start_node = {};
 	nav_node_ref_t goal_node = {};
 
-	//! Working node storage and open list for the current search.
+	//! Working node storage and open set for the current search.
 	std::vector<nav_search_node_t> nodes;
-	std::vector<int32_t> open_list;
+	std::priority_queue<nav_a_star_open_item_t, std::vector<nav_a_star_open_item_t>, nav_a_star_open_item_greater_t> open_heap;
+	uint32_t open_sequence = 0;
 	std::unordered_map<nav_node_key_t, int32_t, nav_node_key_hash_t> node_lookup;
 
 	//! Optional tile-route filter storage/copy to extend lifetime.
 	std::vector<nav_tile_cluster_key_t> tile_route_storage;
+	//! O(1) route membership set built from `tile_route_storage`.
+	std::unordered_set<nav_tile_cluster_key_t, nav_tile_cluster_key_hash_t> tile_route_lookup;
+	//! Successful edge-validation cache keyed by unordered node-pairs to reduce repeat traces.
+	std::unordered_set<uint64_t> successful_edge_cache;
 	//! Pointer to either `tile_route_storage` or nullptr when no filter applies.
 	const std::vector<nav_tile_cluster_key_t> *tileRouteFilter = nullptr;
 
@@ -67,6 +95,10 @@ struct nav_a_star_state_t {
 	int32_t max_nodes = 8192;
 	uint64_t search_budget_ms = 64;
 	uint64_t step_start_ms = 0;
+	//! Clearance pruning enabled when query agent is taller than baked mesh agent.
+	bool clearance_prune_enabled = false;
+	//! Required additional clearance in z-quants above baked mesh hull.
+	uint32_t required_extra_clearance_quants = 0;
 	double best_f_cost_seen = std::numeric_limits<double>::infinity();
 	int32_t stagnation_count = 0;
 	bool hit_stagnation_limit = false;
@@ -76,6 +108,8 @@ struct nav_a_star_state_t {
 	int32_t no_node_count = 0;
 	int32_t tile_filter_reject_count = 0;
 	int32_t edge_reject_count = 0;
+	int32_t edge_cache_hit_count = 0;
+	int32_t edge_cache_store_count = 0;
 };
 
 /**

--- a/src/baseq2rtxp/svgame/svg_commands_server.cpp
+++ b/src/baseq2rtxp/svgame/svg_commands_server.cpp
@@ -10,9 +10,17 @@
 #include "svgame/nav/svg_nav.h"
 #include "svgame/nav/svg_nav_save.h"
 #include "svgame/nav/svg_nav_load.h"
+#include "svgame/nav/svg_nav_path_process.h"
+#include "svgame/nav/svg_nav_request.h"
+#include "svgame/nav/svg_nav_traversal.h"
 
 // Monster types for AI debug introspection.
 #include "svgame/entities/monster/svg_monster_testdummy.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
 
 /**
 *   @brief  
@@ -332,6 +340,424 @@ static void ServerCommand_NavLoad_f( void ) {
 	gi.cprintf( nullptr, PRINT_HIGH, "nav_load: loaded '%s'\n", filename );
 }
 
+/**
+*	@brief	Generate and immediately save a navigation voxelmesh cache file.
+*	@note	Usage: sv nav_bake [filename]
+**/
+static void ServerCommand_NavBake_f( void ) {
+	char defaultFilename[ MAX_QPATH ] = {};
+	const char *filename = nullptr;
+
+	if ( gi.argc() >= 3 ) {
+		filename = gi.argv( 2 );
+	} else if ( SVG_Nav_BuildDefaultCacheFilename( defaultFilename, sizeof( defaultFilename ) ) ) {
+		filename = defaultFilename;
+	} else {
+		gi.cprintf( nullptr, PRINT_HIGH, "Usage: sv nav_bake <filename>\n" );
+		return;
+	}
+
+	SVG_Nav_GenerateVoxelMesh();
+	if ( !g_nav_mesh ) {
+		gi.cprintf( nullptr, PRINT_HIGH, "nav_bake: generation failed (mesh unavailable)\n" );
+		return;
+	}
+
+	if ( !SVG_Nav_SaveVoxelMesh( filename ) ) {
+		gi.cprintf( nullptr, PRINT_HIGH, "nav_bake: failed to write '%s'\n", filename );
+		return;
+	}
+
+	gi.cprintf( nullptr, PRINT_HIGH, "nav_bake: generated + wrote '%s'\n", filename );
+}
+
+/**
+*	@brief	Print a compact runtime dashboard for nav mesh + async queue profiling.
+*	@note	Usage: sv nav_profile_dump
+**/
+static void ServerCommand_NavProfileDump_f( void ) {
+	const nav_mesh_t *mesh = g_nav_mesh.get();
+	nav_async_queue_profile_t queueProfile = {};
+	nav_backend_profile_t backendProfile = {};
+	SVG_Nav_GetAsyncQueueProfile( &queueProfile );
+	SVG_Nav_GetBackendProfile( &backendProfile );
+
+	const int32_t queueTimeBudgetMs = SVG_Nav_GetAsyncQueueFrameBudgetMs();
+	const double avgQueueWaitMs = ( queueProfile.queue_wait_samples > 0 )
+		? ( ( double )queueProfile.total_queue_wait_ms / ( double )queueProfile.queue_wait_samples )
+		: 0.0;
+
+	char cacheFilename[ MAX_QPATH ] = {};
+	const bool hasDefaultCacheName = SVG_Nav_BuildDefaultCacheFilename( cacheFilename, sizeof( cacheFilename ) );
+
+	gi.cprintf( nullptr, PRINT_HIGH, "=== nav_profile_dump ===\n" );
+	gi.cprintf( nullptr, PRINT_HIGH, "backend=%s mesh_loaded=%d map=%s\n",
+		SVG_Nav_GetPathBackendName(),
+		mesh ? 1 : 0,
+		level.mapname[ 0 ] ? level.mapname : "<none>" );
+	gi.cprintf( nullptr, PRINT_HIGH, "cache auto_load=%d auto_bake_missing=%d auto_save_after_bake=%d require_hash_match=%d default_cache=%s\n",
+		nav_cache_auto_load ? nav_cache_auto_load->integer : 0,
+		nav_cache_auto_bake_missing ? nav_cache_auto_bake_missing->integer : 0,
+		nav_cache_auto_save_after_bake ? nav_cache_auto_save_after_bake->integer : 0,
+		nav_cache_require_hash_match ? nav_cache_require_hash_match->integer : 0,
+		hasDefaultCacheName ? cacheFilename : "<unavailable>" );
+
+	if ( mesh ) {
+		gi.cprintf( nullptr, PRINT_HIGH, "mesh world_tiles=%d inline_models=%d total_tiles=%d total_cells=%d total_layers=%d cell_size=%.2f z_quant=%.2f tile_size=%d\n",
+			( int )mesh->world_tiles.size(),
+			mesh->num_inline_models,
+			mesh->total_tiles,
+			mesh->total_xy_cells,
+			mesh->total_layers,
+			( float )mesh->cell_size_xy,
+			( float )mesh->z_quant,
+			mesh->tile_size );
+		gi.cprintf( nullptr, PRINT_HIGH, "generation world_ms=%.2f inline_ms=%.2f total_ms=%.2f generated_at_ms=%llu\n",
+			mesh->profile_world_gen_ms,
+			mesh->profile_inline_gen_ms,
+			mesh->profile_total_gen_ms,
+			( unsigned long long )mesh->profile_generated_at_ms );
+	}
+
+	gi.cprintf( nullptr, PRINT_HIGH, "async queue_depth=%d queue_peak=%d enqueued=%d refreshed=%d processed=%d completed=%d failed=%d cancelled=%d prepare_failures=%d expansions=%lld\n",
+		queueProfile.queue_depth,
+		queueProfile.queue_peak_depth,
+		queueProfile.total_enqueued,
+		queueProfile.total_refreshed,
+		queueProfile.total_processed,
+		queueProfile.total_completed,
+		queueProfile.total_failed,
+		queueProfile.total_cancelled,
+		queueProfile.total_prepare_failures,
+		( long long )queueProfile.total_expansions );
+	gi.cprintf( nullptr, PRINT_HIGH, "async wait_avg_ms=%.2f wait_max_ms=%llu wait_samples=%d frame_elapsed_ms=%llu frame_processed=%d frame_expansions=%d budget_req=%d budget_expand=%d budget_queue_ms=%d configured_queue_budget_ms=%d over_budget_frames=%d\n",
+		avgQueueWaitMs,
+		( unsigned long long )queueProfile.max_queue_wait_ms,
+		queueProfile.queue_wait_samples,
+		( unsigned long long )queueProfile.last_frame_elapsed_ms,
+		queueProfile.last_frame_processed,
+		queueProfile.last_frame_expansions,
+		queueProfile.last_frame_request_budget,
+		queueProfile.last_frame_expansion_budget,
+		queueProfile.last_frame_queue_budget_ms,
+		queueTimeBudgetMs,
+		queueProfile.frame_over_budget_count );
+
+	const double detourAvgMs = ( backendProfile.detour_queries > 0 )
+		? ( ( double )backendProfile.detour_total_ms / ( double )backendProfile.detour_queries )
+		: 0.0;
+	gi.cprintf( nullptr, PRINT_HIGH, "backend detour_queries=%d detour_success=%d detour_failed=%d detour_avg_ms=%.2f detour_max_ms=%llu detour_points_before=%lld detour_points_after=%lld\n",
+		backendProfile.detour_queries,
+		backendProfile.detour_success,
+		backendProfile.detour_failed,
+		detourAvgMs,
+		( unsigned long long )backendProfile.detour_max_ms,
+		( long long )backendProfile.detour_points_before,
+		( long long )backendProfile.detour_points_after );
+}
+
+/**
+*	@brief	Reset async queue profiling counters used by nav_profile_dump.
+*	@note	Usage: sv nav_profile_reset
+**/
+static void ServerCommand_NavProfileReset_f( void ) {
+	SVG_Nav_ResetAsyncQueueProfile();
+	SVG_Nav_ResetBackendProfile();
+	gi.cprintf( nullptr, PRINT_HIGH, "nav_profile_reset: counters cleared\n" );
+}
+
+/**
+*	@brief	Parse a floating-point server-command argument.
+**/
+static bool Nav_ParseDoubleArg( const int32_t argIndex, double *outValue ) {
+	if ( !outValue ) {
+		return false;
+	}
+
+	const char *text = gi.argv( argIndex );
+	if ( !text || !text[ 0 ] ) {
+		return false;
+	}
+
+	char *endPtr = nullptr;
+	const double value = strtod( text, &endPtr );
+	if ( endPtr == text || ( endPtr && endPtr[ 0 ] != '\0' ) ) {
+		return false;
+	}
+
+	*outValue = value;
+	return true;
+}
+
+/**
+*	@brief	Deterministic 32-bit LCG used by nav self-tests.
+**/
+static inline uint32_t NavSelfTest_NextU32( uint32_t *state ) {
+	*state = ( *state * 1664525u ) + 1013904223u;
+	return *state;
+}
+
+/**
+*	@brief	Generate a deterministic random double in [minValue, maxValue].
+**/
+static inline double NavSelfTest_RandRange( uint32_t *state, const double minValue, const double maxValue ) {
+	const double t = ( double )( NavSelfTest_NextU32( state ) & 0x00FFFFFFu ) / ( double )0x01000000u;
+	return minValue + ( ( maxValue - minValue ) * t );
+}
+
+/**
+*	@brief	Run fast deterministic nav-space and transform invariants.
+*	@note	Usage: sv nav_selftest [iterations]
+**/
+static void ServerCommand_NavSelfTest_f( void ) {
+	int32_t iterations = 256;
+	if ( gi.argc() >= 3 ) {
+		iterations = atoi( gi.argv( 2 ) );
+	}
+	iterations = std::max( 1, std::min( iterations, 10000 ) );
+
+	int32_t checks = 0;
+	int32_t failures = 0;
+	int32_t skipped = 0;
+	double maxError = 0.0;
+	uint32_t rngState = 0xC0DEFACEu;
+
+	auto recordError = [&]( const char *label, const double error, const double tolerance ) {
+		checks++;
+		maxError = std::max( maxError, error );
+		if ( error <= tolerance ) {
+			return;
+		}
+
+		failures++;
+		if ( failures <= 8 ) {
+			gi.cprintf( nullptr, PRINT_HIGH, "[nav-selftest][FAIL] %s error=%.6f tolerance=%.6f\n", label, error, tolerance );
+		}
+	};
+
+	for ( int32_t i = 0; i < iterations; i++ ) {
+		const Vector3 origin = {
+			( float )NavSelfTest_RandRange( &rngState, -2048.0, 2048.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -2048.0, 2048.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -512.0, 512.0 )
+		};
+		const Vector3 angles = {
+			( float )NavSelfTest_RandRange( &rngState, -180.0, 180.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -180.0, 180.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -180.0, 180.0 )
+		};
+		const Vector3 localPoint = {
+			( float )NavSelfTest_RandRange( &rngState, -256.0, 256.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -256.0, 256.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -256.0, 256.0 )
+		};
+
+		const nav_rigid_xform_t xform = SVG_Nav_BuildRigidXform( origin, angles );
+		const Vector3 worldPoint = SVG_Nav_WorldFromLocal( xform, localPoint );
+		const Vector3 localPointRoundTrip = SVG_Nav_LocalFromWorld( xform, worldPoint );
+		const double pointError = QM_Vector3LengthDP( QM_Vector3Subtract( localPointRoundTrip, localPoint ) );
+		recordError( "xform_point_roundtrip", pointError, 0.02 );
+
+		const double forwardLenError = std::fabs( QM_Vector3LengthDP( xform.forward ) - 1.0 );
+		const double sideLenError = std::fabs( QM_Vector3LengthDP( xform.side ) - 1.0 );
+		const double upLenError = std::fabs( QM_Vector3LengthDP( xform.up ) - 1.0 );
+		recordError( "xform_basis_forward_len", forwardLenError, 0.02 );
+		recordError( "xform_basis_side_len", sideLenError, 0.02 );
+		recordError( "xform_basis_up_len", upLenError, 0.02 );
+
+		const double fsDotError = std::fabs( QM_Vector3DotProduct( xform.forward, xform.side ) );
+		const double fuDotError = std::fabs( QM_Vector3DotProduct( xform.forward, xform.up ) );
+		const double suDotError = std::fabs( QM_Vector3DotProduct( xform.side, xform.up ) );
+		recordError( "xform_basis_dot_fs", fsDotError, 0.02 );
+		recordError( "xform_basis_dot_fu", fuDotError, 0.02 );
+		recordError( "xform_basis_dot_su", suDotError, 0.02 );
+
+		const Vector3 localMins = {
+			( float )NavSelfTest_RandRange( &rngState, -96.0, -16.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -96.0, -16.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -64.0, -8.0 )
+		};
+		const Vector3 localMaxs = {
+			( float )NavSelfTest_RandRange( &rngState, 16.0, 96.0 ),
+			( float )NavSelfTest_RandRange( &rngState, 16.0, 96.0 ),
+			( float )NavSelfTest_RandRange( &rngState, 8.0, 64.0 )
+		};
+		double maxCornerError = 0.0;
+		for ( int32_t cornerMask = 0; cornerMask < 8; cornerMask++ ) {
+			const Vector3 localCorner = {
+				( cornerMask & 1 ) ? localMaxs.x : localMins.x,
+				( cornerMask & 2 ) ? localMaxs.y : localMins.y,
+				( cornerMask & 4 ) ? localMaxs.z : localMins.z
+			};
+			const Vector3 worldCorner = SVG_Nav_WorldFromLocal( xform, localCorner );
+			const Vector3 roundTripCorner = SVG_Nav_LocalFromWorld( xform, worldCorner );
+			const double cornerError = QM_Vector3LengthDP( QM_Vector3Subtract( roundTripCorner, localCorner ) );
+			maxCornerError = std::max( maxCornerError, cornerError );
+		}
+		recordError( "xform_aabb_corner_roundtrip", maxCornerError, 0.03 );
+
+		Vector3 localDir = {
+			( float )NavSelfTest_RandRange( &rngState, -1.0, 1.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -1.0, 1.0 ),
+			( float )NavSelfTest_RandRange( &rngState, -1.0, 1.0 )
+		};
+		if ( QM_Vector3LengthDP( localDir ) < 0.0001 ) {
+			localDir = { 1.0f, 0.0f, 0.0f };
+		}
+		localDir = QM_Vector3NormalizeDP( localDir );
+
+		const Vector3 worldDir = SVG_Nav_WorldDirectionFromLocal( xform, localDir );
+		const Vector3 localDirRoundTrip = SVG_Nav_LocalDirectionFromWorld( xform, worldDir );
+		const double directionError = QM_Vector3LengthDP( QM_Vector3Subtract( localDirRoundTrip, localDir ) );
+		recordError( "xform_direction_roundtrip", directionError, 0.02 );
+	}
+
+	const nav_mesh_t *mesh = g_nav_mesh.get();
+	if ( !mesh ) {
+		skipped += iterations * 2;
+	} else {
+		const nav_agent_profile_t resolved = SVG_Nav_ResolveAgentProfile( mesh, nullptr, nullptr );
+		if ( SVG_Nav_IsAgentBoundsValid( resolved.mins, resolved.maxs ) ) {
+			for ( int32_t i = 0; i < iterations; i++ ) {
+				const Vector3 feetPos = {
+					( float )NavSelfTest_RandRange( &rngState, -2048.0, 2048.0 ),
+					( float )NavSelfTest_RandRange( &rngState, -2048.0, 2048.0 ),
+					( float )NavSelfTest_RandRange( &rngState, -256.0, 512.0 )
+				};
+
+				const Vector3 centerPos = SVG_Nav_ConvertFeetToCenter( mesh, feetPos, &resolved.mins, &resolved.maxs );
+				const Vector3 feetRoundTrip = SVG_Nav_ConvertCenterToFeet( mesh, centerPos, &resolved.mins, &resolved.maxs );
+				const double feetError = QM_Vector3LengthDP( QM_Vector3Subtract( feetRoundTrip, feetPos ) );
+				recordError( "feet_center_roundtrip", feetError, 0.02 );
+			}
+		} else {
+			skipped += iterations;
+		}
+
+		const double tileWorldSize = mesh->cell_size_xy * mesh->tile_size;
+		if ( tileWorldSize > 0.0 && mesh->cell_size_xy > 0.0 && mesh->tile_size > 0 ) {
+			for ( int32_t i = 0; i < iterations; i++ ) {
+				const double worldX = NavSelfTest_RandRange( &rngState, -4096.0, 4096.0 );
+				const int32_t tileX = Nav_WorldToTileCoord( worldX, tileWorldSize );
+				const double tileOriginX = tileX * tileWorldSize;
+				const bool tileMembershipOk = ( worldX >= ( tileOriginX - NAV_TILE_EPSILON ) )
+					&& ( worldX <= ( tileOriginX + tileWorldSize + NAV_TILE_EPSILON ) );
+				recordError( "tile_membership", tileMembershipOk ? 0.0 : 1.0, 0.5 );
+
+				const double worldInTile = NavSelfTest_RandRange( &rngState, tileOriginX, tileOriginX + tileWorldSize - 0.001 );
+				const int32_t cellX = Nav_WorldToCellCoord( worldInTile, tileOriginX, mesh->cell_size_xy );
+				const bool cellIndexOk = cellX >= 0 && cellX < mesh->tile_size;
+				recordError( "cell_index_bounds", cellIndexOk ? 0.0 : 1.0, 0.5 );
+			}
+		} else {
+			skipped += iterations;
+		}
+	}
+
+	gi.cprintf( nullptr, PRINT_HIGH, "[nav-selftest] result=%s iterations=%d checks=%d failed=%d skipped=%d max_error=%.6f\n",
+		failures == 0 ? "PASS" : "FAIL",
+		iterations,
+		checks,
+		failures,
+		skipped,
+		maxError );
+}
+
+/**
+*	@brief	Run a deterministic path query and emit machine-parseable diagnostics.
+*	@note	Usage:
+*			- sv nav_query_path <start_x> <start_y> <start_z> <goal_x> <goal_y> <goal_z>
+*			- sv nav_query_path <query_id> <start_x> <start_y> <start_z> <goal_x> <goal_y> <goal_z>
+**/
+static void ServerCommand_NavQueryPath_f( void ) {
+	const bool hasQueryId = gi.argc() >= 9;
+	const int32_t coordBase = hasQueryId ? 3 : 2;
+	const char *queryId = hasQueryId ? gi.argv( 2 ) : "q";
+
+	if ( gi.argc() < ( coordBase + 6 ) ) {
+		gi.cprintf( nullptr, PRINT_HIGH, "Usage: sv nav_query_path [query_id] <start_x> <start_y> <start_z> <goal_x> <goal_y> <goal_z>\n" );
+		return;
+	}
+
+	if ( !g_nav_mesh ) {
+		gi.cprintf( nullptr, PRINT_HIGH, "[nav-query] id=%s found=0 points=0 segments_ok=0 invalid_segment=-1 error=no_mesh\n", queryId );
+		return;
+	}
+
+	double startX = 0.0;
+	double startY = 0.0;
+	double startZ = 0.0;
+	double goalX = 0.0;
+	double goalY = 0.0;
+	double goalZ = 0.0;
+	const bool parsed = Nav_ParseDoubleArg( coordBase + 0, &startX )
+		&& Nav_ParseDoubleArg( coordBase + 1, &startY )
+		&& Nav_ParseDoubleArg( coordBase + 2, &startZ )
+		&& Nav_ParseDoubleArg( coordBase + 3, &goalX )
+		&& Nav_ParseDoubleArg( coordBase + 4, &goalY )
+		&& Nav_ParseDoubleArg( coordBase + 5, &goalZ );
+	if ( !parsed ) {
+		gi.cprintf( nullptr, PRINT_HIGH, "[nav-query] id=%s found=0 points=0 segments_ok=0 invalid_segment=-1 error=parse\n", queryId );
+		return;
+	}
+
+	const Vector3 startOrigin = { (float)startX, (float)startY, (float)startZ };
+	const Vector3 goalOrigin = { (float)goalX, (float)goalY, (float)goalZ };
+
+	svg_nav_path_policy_t policy = {};
+	const nav_agent_profile_t resolved = SVG_Nav_ResolveAgentProfile( g_nav_mesh.get(), nullptr, nullptr );
+	policy.agent_mins = resolved.mins;
+	policy.agent_maxs = resolved.maxs;
+	policy.max_step_height = resolved.max_step_height;
+	policy.max_drop_height = resolved.max_drop_height;
+	policy.drop_cap = resolved.drop_cap;
+	policy.max_slope_deg = resolved.max_slope_deg;
+
+	nav_traversal_path_t path = {};
+	const bool found = SVG_Nav_GenerateTraversalPathForOriginEx_WithAgentBBox(
+		startOrigin,
+		goalOrigin,
+		&path,
+		policy.agent_mins,
+		policy.agent_maxs,
+		&policy,
+		policy.enable_goal_z_layer_blend,
+		policy.blend_start_dist,
+		policy.blend_full_dist,
+		nullptr );
+
+	bool segmentsOk = false;
+	int32_t invalidSegment = -1;
+	if ( found ) {
+		segmentsOk = true;
+		const int32_t segmentCount = std::max( 0, path.num_points - 1 );
+		for ( int32_t i = 0; i < segmentCount; i++ ) {
+			const bool traversable = Nav_CanTraverseStep_ExplicitBBox(
+				g_nav_mesh.get(),
+				path.points[ i ],
+				path.points[ i + 1 ],
+				policy.agent_mins,
+				policy.agent_maxs,
+				nullptr,
+				&policy );
+			if ( !traversable ) {
+				segmentsOk = false;
+				invalidSegment = i;
+				break;
+			}
+		}
+	}
+
+	gi.cprintf( nullptr, PRINT_HIGH, "[nav-query] id=%s found=%d points=%d segments_ok=%d invalid_segment=%d\n",
+		queryId,
+		found ? 1 : 0,
+		path.num_points,
+		segmentsOk ? 1 : 0,
+		invalidSegment );
+
+	SVG_Nav_FreeTraversalPath( &path );
+}
+
 
 /*
 ==============================================================================
@@ -599,6 +1025,16 @@ void SVG_ServerCommand(void) {
         ServerCommand_NavSave_f();
     else if ( Q_stricmp( cmd, "nav_load" ) == 0 )
         ServerCommand_NavLoad_f();
+    else if ( Q_stricmp( cmd, "nav_bake" ) == 0 )
+        ServerCommand_NavBake_f();
+    else if ( Q_stricmp( cmd, "nav_profile_dump" ) == 0 )
+        ServerCommand_NavProfileDump_f();
+    else if ( Q_stricmp( cmd, "nav_profile_reset" ) == 0 )
+        ServerCommand_NavProfileReset_f();
+    else if ( Q_stricmp( cmd, "nav_selftest" ) == 0 )
+        ServerCommand_NavSelfTest_f();
+    else if ( Q_stricmp( cmd, "nav_query_path" ) == 0 )
+        ServerCommand_NavQueryPath_f();
     else if ( Q_stricmp( cmd, "nav_cell" ) == 0 )
         ServerCommand_NavCell_f();
     else if ( Q_stricmp( cmd, "addip" ) == 0 )

--- a/src/baseq2rtxp/svgame/svg_main.cpp
+++ b/src/baseq2rtxp/svgame/svg_main.cpp
@@ -810,6 +810,8 @@ void SVG_RunFrame(void) {
     SVG_PushMove_UpdateMoveWithEntities();
 	//! Make sure to update the navigation system.
 	SVG_Nav_RefreshInlineModelRuntime();
+	// Refresh per-frame dynamic occupancy before advancing async path requests.
+	SVG_Nav_Occupancy_PopulateFromEntities();
 
 	/**
 	*	WID: LUA: CallBack.

--- a/src/baseq2rtxp/svgame/svg_spawn.cpp
+++ b/src/baseq2rtxp/svgame/svg_spawn.cpp
@@ -39,6 +39,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "svgame/gamemodes/svg_gm_basemode.h"
 
 #include "svgame/nav/svg_nav.h"
+#include "svgame/nav/svg_nav_load.h"
+#include "svgame/nav/svg_nav_save.h"
 
 
 
@@ -412,6 +414,50 @@ static const gitem_t *_GetItemByClassname( const char *classname ) {
 }
 
 /**
+*   @brief  Try to load a cached nav mesh for the current map and optionally bake/save on cache miss.
+**/
+static void SVG_Nav_TryAutoLoadOrBakeForMap( void ) {
+	char cacheFilename[ MAX_QPATH ] = {};
+	if ( !SVG_Nav_BuildDefaultCacheFilename( cacheFilename, sizeof( cacheFilename ) ) ) {
+		gi.dprintf( "[Nav] auto cache: skipped (map name unavailable)\n" );
+		return;
+	}
+
+	bool loaded = false;
+	if ( nav_cache_auto_load && nav_cache_auto_load->integer != 0 ) {
+		loaded = SVG_Nav_LoadVoxelMesh( cacheFilename );
+		if ( loaded ) {
+			gi.dprintf( "[Nav] auto cache: loaded '%s'\n", cacheFilename );
+		} else {
+			gi.dprintf( "[Nav] auto cache: miss '%s'\n", cacheFilename );
+		}
+	}
+
+	const bool autoBakeEnabled = nav_cache_auto_bake_missing && nav_cache_auto_bake_missing->integer != 0;
+	if ( loaded || !autoBakeEnabled ) {
+		return;
+	}
+
+	gi.dprintf( "[Nav] auto cache: baking '%s'\n", cacheFilename );
+	SVG_Nav_GenerateVoxelMesh();
+	if ( !g_nav_mesh ) {
+		gi.dprintf( "[Nav] auto cache: bake failed (mesh unavailable)\n" );
+		return;
+	}
+
+	const bool autoSaveEnabled = nav_cache_auto_save_after_bake && nav_cache_auto_save_after_bake->integer != 0;
+	if ( !autoSaveEnabled ) {
+		return;
+	}
+
+	if ( SVG_Nav_SaveVoxelMesh( cacheFilename ) ) {
+		gi.dprintf( "[Nav] auto cache: wrote '%s'\n", cacheFilename );
+	} else {
+		gi.dprintf( "[Nav] auto cache: failed to write '%s'\n", cacheFilename );
+	}
+}
+
+/**
 *   @brief  Loads in the map name and iterates over the collision model's parsed key/value
 *           pairs in order to spawn entities appropriately matching the pair dictionary fields
 *           of each entity.
@@ -641,6 +687,7 @@ void SVG_SpawnEntities( const char *mapname, const char *spawnpoint, const cm_en
 	// Initialize navigation system after entities have post-spawned.
 	// This ensures all inline models (brush entities) have their proper modelindex set.
 	SVG_Nav_Init();
+	SVG_Nav_TryAutoLoadOrBakeForMap();
 
     // Initialize a fresh clients array.
     //game.clients = SVG_Clients_Reallocate( game.maxclients );

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -41,11 +41,9 @@ cvar_t  *cl_rollhack;
 cvar_t  *cl_noglow;
 cvar_t  *cl_nolerp;
 
-#if USE_DEBUG
 cvar_t  *cl_shownet;
 cvar_t  *cl_showmiss;
 cvar_t  *cl_showclamp;
-#endif
 
 QEXTERN_C_ENCLOSE( cvar_t *cl_player_model; );
 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -78,9 +78,7 @@ static int      com_argc;
 cvar_t  *z_perturb;
 #endif
 
-#if USE_DEBUG
 QEXTERN_C_ENCLOSE( cvar_t *developer; );
-#endif
 cvar_t  *timescale;
 cvar_t  *fixedtime;
 QEXTERN_C_ENCLOSE( cvar_t *dedicated; );
@@ -890,6 +888,8 @@ void Qcommon_Init(int argc, char **argv)
 #endif
 #if USE_DEBUG
     developer = Cvar_Get("developer", "1", 0);
+#else
+    developer = Cvar_Get("developer", "0", 0);
 #endif
     timescale = Cvar_Get("timescale", "1", CVAR_CHEAT);
     fixedtime = Cvar_Get("fixedtime", "0", CVAR_CHEAT);


### PR DESCRIPTION
Introduce end-to-end navmesh automation: add GitHub workflows (.github/workflows/navmesh-ci.yml and navmesh-automation.yml) for CI builds, sanitizers, clang-tidy/format checks and a manual automation entry. Add PowerShell tooling and examples (scripts/nav_*.ps1, nav_maps_example.txt, CSV examples) including bake, smoke, profile dashboard and pipeline scripts for offline baking, regression smoke tests, dashboarding and budget checks. Add documentation (docs/NAVMESH_AUTOMATION.md, NAVMESH_COORDINATE_SPACES.md) and an automation pointer in NAVMESH_TROUBLESHOOTING.md. Wire new nav agent sources/headers into the build (src/.../nav/svg_nav_agent.* and updates across multiple svg_nav files) and update CMakeSources.cmake to include them. Misc: add .vscode/settings.json and a small common.h change to unconditionally expose the 'developer' cvar.